### PR TITLE
OpenSSL Provider and Store Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+.vs
 .clang-format
 .DS_Store
 *~
@@ -41,3 +42,4 @@ workflow/
 examples/wasi_serde_json/target/
 # WASM test data
 tests/runtime/wasm/go/*.wasm
+/out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ option(FLB_WASM_STACK_PROTECT  "Build with WASM runtime with strong stack protec
 option(FLB_ENFORCE_ALIGNMENT   "Enable limited platform specific aligned memory access" No)
 option(FLB_KAFKA               "Enable Kafka support"         Yes)
 option(FLB_ZIG                 "Enable zig integration"       Yes)
+option(FLB_OPENSSL_STORE       "Enable OpenSSL Store Support for TLS"       No)
 
 # Native Metrics Support (cmetrics)
 option(FLB_METRICS             "Enable metrics support"       Yes)
@@ -410,6 +411,15 @@ if (FLB_ZIG)
       set(FLB_ZIG On)
     endif()
   endif()
+endif()
+
+# Ensure OpenSSL Store support is available if TLS is enabled
+if (FLB_OPENSSL_STORE)
+  if(NOT FLB_TLS)
+    message(FATAL_ERROR "FLB_ENABLE_OPENSSL_STORE requires FLB_TLS to be enabled.")
+  endif()
+  message(STATUS "OpenSSL Store defined")
+  add_definitions(-DFLB_USE_OPENSSL_STORE=1)
 endif()
 
 if(FLB_SMALL)

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -100,6 +100,8 @@ struct flb_config {
     struct flb_cf *cf_opts;
     struct mk_list cf_parsers_list;
 
+    char* openssl_providers;
+
     flb_sds_t program_name;      /* argv[0] */
 
     /*
@@ -403,5 +405,9 @@ enum conf_type {
 /* Scheduler */
 #define FLB_CONF_STR_SCHED_CAP        "scheduler.cap"
 #define FLB_CONF_STR_SCHED_BASE       "scheduler.base"
+
+/* OpenSSL Providers */
+#define FLB_CONF_STR_OPENSSL_PROVIDERS \
+                                      "openssl.providers"
 
 #endif

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -448,6 +448,7 @@ struct flb_input_instance {
     char *tls_min_version;               /* Minimum protocol version of TLS */
     char *tls_max_version;               /* Maximum protocol version of TLS */
     char *tls_ciphers;                   /* TLS ciphers */
+    char *tls_provider_query;            /* OpenSSL Provider Query */
 
     struct mk_list *tls_config_map;
 

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -369,6 +369,7 @@ struct flb_output_instance {
     char *tls_min_version;               /* Minimum protocol version of TLS */
     char *tls_max_version;               /* Maximum protocol version of TLS */
     char *tls_ciphers;                   /* TLS ciphers */
+    char *tls_provider_query;            /* OpenSSL Provider Query */
 #endif
 
     /*

--- a/include/fluent-bit/flb_upstream_node.h
+++ b/include/fluent-bit/flb_upstream_node.h
@@ -43,6 +43,7 @@ struct flb_upstream_node {
     char *tls_crt_file;       /* Certificate                  */
     char *tls_key_file;       /* Cert Key                     */
     char *tls_key_passwd;     /* Cert Key Password            */
+    char *tls_provider_query; /* OpenSSL Provider Query       */
 
     /* context with mbedTLS contexts and data */
     struct flb_tls *tls;
@@ -74,6 +75,7 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
                                                    const char *tls_crt_file,
                                                    const char *tls_key_file,
                                                    const char *tls_key_passwd,
+                                                   const char *tls_provider_query,
                                                    struct flb_hash_table *ht,
                                                    struct flb_config *config);
 const char *flb_upstream_node_get_property(const char *prop,

--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -69,7 +69,8 @@ struct flb_tls_backend {
     void *(*context_create) (int, int, int,
                              const char *, const char *,
                              const char *, const char *,
-                             const char *, const char *);
+                             const char *, const char *,
+                             const char *);
 
     /* destroy backend context */
     void (*context_destroy) (void *);
@@ -115,7 +116,8 @@ struct flb_tls *flb_tls_create(int mode,
                                const char *vhost,
                                const char *ca_path,
                                const char *ca_file, const char *crt_file,
-                               const char *key_file, const char *key_passwd);
+                               const char *key_file, const char *key_passwd,
+                               const char *additional_data);
 
 int flb_tls_destroy(struct flb_tls *tls);
 

--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -110,6 +110,9 @@ struct flb_tls {
 
 int flb_tls_init();
 
+void flb_tls_configure(struct flb_config* config);
+void flb_tls_cleanup(void);
+
 struct flb_tls *flb_tls_create(int mode,
                                int verify,
                                int debug,

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -1741,7 +1741,7 @@ static int flb_kubelet_network_init(struct flb_kube *ctx, struct flb_config *con
                                 ctx->tls_vhost,
                                 ctx->tls_ca_path,
                                 ctx->tls_ca_file,
-                                NULL, NULL, NULL);
+                                NULL, NULL, NULL, NULL);
         if (!ctx->kubelet_tls) {
             return -1;
         }
@@ -1794,7 +1794,7 @@ static int flb_kube_network_init(struct flb_kube *ctx, struct flb_config *config
                                   ctx->tls_vhost,
                                   ctx->tls_ca_path,
                                   ctx->tls_ca_file,
-                                  NULL, NULL, NULL);
+                                  NULL, NULL, NULL, NULL);
         if (!ctx->tls) {
             return -1;
         }

--- a/plugins/filter_nightfall/nightfall.c
+++ b/plugins/filter_nightfall/nightfall.c
@@ -97,7 +97,7 @@ static int cb_nightfall_init(struct flb_filter_instance *f_ins,
                               ctx->tls_vhost,
                               ctx->tls_ca_path,
                               NULL,
-                              NULL, NULL, NULL);
+                              NULL, NULL, NULL, NULL);
     if (!ctx->tls) {
         flb_plg_error(f_ins, "tls initialization error");
         flb_free(ctx);

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.c
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.c
@@ -109,7 +109,7 @@ static int network_init(struct k8s_events *ctx, struct flb_config *config)
                                   ctx->tls_vhost,
                                   ctx->tls_ca_path,
                                   ctx->tls_ca_file,
-                                  NULL, NULL, NULL);
+                                  NULL, NULL, NULL, NULL);
         if (!ctx->tls) {
             return -1;
         }

--- a/plugins/out_azure_blob/azure_blob_conf.c
+++ b/plugins/out_azure_blob/azure_blob_conf.c
@@ -375,6 +375,7 @@ static int flb_azure_blob_apply_remote_configuration(struct flb_azure_blob *cont
                                  NULL,
                                  NULL,
                                  NULL,
+                                 NULL,
                                  NULL);
 
     if (tls_context == NULL) {

--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -89,7 +89,7 @@ static struct flb_upstream_node *flb_upstream_node_create_url(struct flb_azure_k
                         NULL, sds_host, sds_port, FLB_TRUE, ctx->ins->tls->verify,
                         ctx->ins->tls->verify_hostname,
                         ctx->ins->tls->debug, ctx->ins->tls->vhost, NULL, NULL, NULL,
-                        NULL, NULL, kv, config);
+                        NULL, NULL, NULL, kv, config);
 
                     if (!node) {
                         flb_plg_error(ctx->ins, "error creating resource upstream node");

--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -695,7 +695,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                       ins->tls_ca_file,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
-                                      ins->tls_key_passwd);
+                                      ins->tls_key_passwd,
+                                      ins->tls_provider_query);
 
         if (!ctx->aws_tls) {
             flb_plg_error(ctx->ins, "Failed to create TLS context");
@@ -734,7 +735,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                           ins->tls_ca_file,
                                           ins->tls_crt_file,
                                           ins->tls_key_file,
-                                          ins->tls_key_passwd);
+                                          ins->tls_key_passwd,
+                                          ins->tls_provider_query);
 
         if (!ctx->aws_sts_tls) {
             flb_plg_error(ctx->ins, "Failed to create TLS context");
@@ -765,7 +767,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                              ins->tls_ca_file,
                                              ins->tls_crt_file,
                                              ins->tls_key_file,
-                                             ins->tls_key_passwd);
+                                             ins->tls_key_passwd,
+                                             ins->tls_provider_query);
 
         if (!ctx->google_sts_tls) {
             flb_plg_error(ctx->ins, "Failed to create TLS context");
@@ -793,7 +796,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                              ins->tls_ca_file,
                                              ins->tls_crt_file,
                                              ins->tls_key_file,
-                                             ins->tls_key_passwd);
+                                             ins->tls_key_passwd,
+                                             ins->tls_provider_query);
 
         if (!ctx->google_iam_tls) {
             flb_plg_error(ctx->ins, "Failed to create TLS context");

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -251,7 +251,8 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                                    ins->tls_ca_file,
                                    ins->tls_crt_file,
                                    ins->tls_key_file,
-                                   ins->tls_key_passwd);
+                                   ins->tls_key_passwd,
+                                   ins->tls_provider_query);
 
     if (!ctx->cred_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
@@ -266,7 +267,8 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                                      ins->tls_ca_file,
                                      ins->tls_crt_file,
                                      ins->tls_key_file,
-                                     ins->tls_key_passwd);
+                                     ins->tls_key_passwd,
+                                     ins->tls_provider_query);
     if (!ctx->client_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
         goto error;
@@ -302,7 +304,8 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                                       ins->tls_ca_file,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
-                                      ins->tls_key_passwd);
+                                      ins->tls_key_passwd,
+                                      ins->tls_provider_query);
         if (!ctx->sts_tls) {
             flb_errno();
             goto error;

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -382,7 +382,8 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                           ins->tls_ca_file,
                                           ins->tls_crt_file,
                                           ins->tls_key_file,
-                                          ins->tls_key_passwd);
+                                          ins->tls_key_passwd,
+                                          ins->tls_provider_query);
             if (!ctx->aws_tls) {
                 flb_errno();
                 flb_es_conf_destroy(ctx);
@@ -443,7 +444,8 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                                   ins->tls_ca_file,
                                                   ins->tls_crt_file,
                                                   ins->tls_key_file,
-                                                  ins->tls_key_passwd);
+                                                  ins->tls_key_passwd,
+                                                  ins->tls_provider_query);
                 if (!ctx->aws_sts_tls) {
                     flb_errno();
                     flb_es_conf_destroy(ctx);

--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -157,7 +157,8 @@ static int cb_firehose_init(struct flb_output_instance *ins,
                                    ins->tls_ca_file,
                                    ins->tls_crt_file,
                                    ins->tls_key_file,
-                                   ins->tls_key_passwd);
+                                   ins->tls_key_passwd,
+                                   ins->tls_provider_query);
 
     if (!ctx->cred_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
@@ -172,7 +173,8 @@ static int cb_firehose_init(struct flb_output_instance *ins,
                                      ins->tls_ca_file,
                                      ins->tls_crt_file,
                                      ins->tls_key_file,
-                                     ins->tls_key_passwd);
+                                     ins->tls_key_passwd,
+                                     ins->tls_provider_query);
     if (!ctx->client_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
         goto error;
@@ -208,7 +210,8 @@ static int cb_firehose_init(struct flb_output_instance *ins,
                                       ins->tls_ca_file,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
-                                      ins->tls_key_passwd);
+                                      ins->tls_key_passwd,
+                                      ins->tls_provider_query);
         if (!ctx->sts_tls) {
             flb_errno();
             goto error;

--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -169,7 +169,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                    ins->tls_ca_file,
                                    ins->tls_crt_file,
                                    ins->tls_key_file,
-                                   ins->tls_key_passwd);
+                                   ins->tls_key_passwd, 
+                                   ins->tls_provider_query);
 
     if (!ctx->cred_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
@@ -184,7 +185,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                      ins->tls_ca_file,
                                      ins->tls_crt_file,
                                      ins->tls_key_file,
-                                     ins->tls_key_passwd);
+                                     ins->tls_key_passwd, 
+                                     ins->tls_provider_query);
     if (!ctx->client_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
         goto error;
@@ -227,7 +229,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                       ins->tls_ca_file,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
-                                      ins->tls_key_passwd);
+                                      ins->tls_key_passwd, 
+                                      ins->tls_provider_query);
         if (!ctx->sts_tls) {
             flb_errno();
             goto error;

--- a/plugins/out_opensearch/os_conf.c
+++ b/plugins/out_opensearch/os_conf.c
@@ -257,7 +257,8 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
                                           ins->tls_ca_file,
                                           ins->tls_crt_file,
                                           ins->tls_key_file,
-                                          ins->tls_key_passwd);
+                                          ins->tls_key_passwd,
+                                          ins->tls_provider_query);
             if (!ctx->aws_tls) {
                 flb_errno();
                 flb_os_conf_destroy(ctx);
@@ -318,7 +319,8 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
                                                   ins->tls_ca_file,
                                                   ins->tls_crt_file,
                                                   ins->tls_key_file,
-                                                  ins->tls_key_passwd);
+                                                  ins->tls_key_passwd,
+                                                  ins->tls_provider_query);
                 if (!ctx->aws_sts_tls) {
                     flb_errno();
                     flb_os_conf_destroy(ctx);

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -785,7 +785,8 @@ static int cb_s3_init(struct flb_output_instance *ins,
                                          ins->tls_ca_file,
                                          ins->tls_crt_file,
                                          ins->tls_key_file,
-                                         ins->tls_key_passwd);
+                                         ins->tls_key_passwd, 
+                                         ins->tls_provider_query);
         if (!ctx->client_tls) {
             flb_plg_error(ctx->ins, "Failed to create tls context");
             return -1;
@@ -801,7 +802,8 @@ static int cb_s3_init(struct flb_output_instance *ins,
                                        ins->tls_ca_file,
                                        ins->tls_crt_file,
                                        ins->tls_key_file,
-                                       ins->tls_key_passwd);
+                                       ins->tls_key_passwd, 
+                                       ins->tls_provider_query);
     if (!ctx->provider_tls) {
         flb_errno();
         return -1;
@@ -835,7 +837,8 @@ static int cb_s3_init(struct flb_output_instance *ins,
                                                ins->tls_ca_file,
                                                ins->tls_crt_file,
                                                ins->tls_key_file,
-                                               ins->tls_key_passwd);
+                                               ins->tls_key_passwd, 
+                                               ins->tls_provider_query);
 
         if (!ctx->sts_provider_tls) {
             flb_errno();

--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -383,7 +383,8 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
                               ins->tls_ca_file,
                               ins->tls_crt_file,
                               ins->tls_key_file,
-                              ins->tls_key_passwd);
+                              ins->tls_key_passwd,
+                              ins->tls_provider_query);
     if (!cred_tls) {
         flb_plg_error(ins, "Failed to create TLS instance for AWS Provider");
         flb_errno();
@@ -434,7 +435,8 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
                                  ins->tls_ca_file,
                                  ins->tls_crt_file,
                                  ins->tls_key_file,
-                                 ins->tls_key_passwd);
+                                 ins->tls_key_passwd,
+                                 ins->tls_provider_query);
         if (!sts_tls) {
             flb_plg_error(ins, "Failed to create TLS instance for AWS STS Credential "
                           "Provider");

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -196,6 +196,11 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, ensure_thread_safety_on_hot_reloading)},
 
+     /* OpenSSL Providers */
+     { FLB_CONF_STR_OPENSSL_PROVIDERS,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, openssl_providers) },
+
     {NULL, FLB_CONF_TYPE_OTHER, 0} /* end of array */
 };
 
@@ -295,6 +300,8 @@ struct flb_config *flb_config_init()
     config->hot_reloaded_count = 0;
     config->shutdown_by_hot_reloading = FLB_FALSE;
     config->hot_reloading = FLB_FALSE;
+
+    config->openssl_providers = NULL;
 
 #ifdef FLB_SYSTEM_WINDOWS
     config->win_maxstdio = 512;
@@ -552,6 +559,10 @@ void flb_config_exit(struct flb_config *config)
 
     if (config->cf_main) {
         flb_cf_destroy(config->cf_main);
+    }
+
+    if (config->openssl_providers) {
+        flb_free(config->openssl_providers);
     }
 
     /* cf_opts' lifetime should differ from config's lifetime.

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -391,6 +391,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->tls_crt_file          = NULL;
         instance->tls_key_file          = NULL;
         instance->tls_key_passwd        = NULL;
+        instance->tls_provider_query    = NULL;
 #endif
 
         /* Plugin requires a co-routine context ? */
@@ -668,6 +669,9 @@ int flb_input_set_property(struct flb_input_instance *ins,
     else if (prop_key_check("tls.ciphers", k, len) == 0) {
         flb_utils_set_plugin_string_property("tls.ciphers", &ins->tls_ciphers, tmp);
     }
+    else if (prop_key_check("tls.provider_query", k, len) == 0) {
+        flb_utils_set_plugin_string_property("tls.provider_query", &ins->tls_provider_query, tmp);
+    }
 #endif
     else if (prop_key_check("storage.type", k, len) == 0 && tmp) {
         /* Set the storage type */
@@ -824,6 +828,10 @@ void flb_input_instance_destroy(struct flb_input_instance *ins)
 
     if (ins->tls_ciphers) {
         flb_sds_destroy(ins->tls_ciphers);
+    }
+
+    if (ins->tls_provider_query) {
+        flb_sds_destroy(ins->tls_provider_query);
     }
 
     /* release the tag if any */
@@ -1242,7 +1250,8 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                                   ins->tls_ca_file,
                                   ins->tls_crt_file,
                                   ins->tls_key_file,
-                                  ins->tls_key_passwd);
+                                  ins->tls_key_passwd,
+                                  ins->tls_provider_query);
 
         if (ins->tls == NULL) {
             flb_error("[input %s] error initializing TLS context",

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -120,7 +120,7 @@ static inline struct flb_filter_instance *filter_instance_get(flb_ctx_t *ctx,
     return NULL;
 }
 
-void flb_init_env()
+void flb_init_env(void)
 {
     flb_tls_init();
     flb_coro_init();
@@ -133,6 +133,11 @@ void flb_init_env()
 
     /* libraries */
     cmt_initialize();
+}
+
+void flb_configure_env(struct flb_config* config)
+{
+    flb_tls_configure(config);
 }
 
 flb_ctx_t *flb_create()
@@ -864,6 +869,8 @@ int static do_start(flb_ctx_t *ctx)
 
     flb_debug("[lib] context set: %p", ctx);
 
+    flb_configure_env(ctx->config);
+
     /* set context as the last active one */
 
     /* spawn worker thread */
@@ -980,6 +987,8 @@ int flb_stop(flb_ctx_t *ctx)
         flb_errno();
     }
     flb_debug("[lib] Fluent Bit engine stopped");
+
+    flb_tls_cleanup();
 
     return ret;
 }

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -220,7 +220,8 @@ struct flb_oauth2 *flb_oauth2_create(struct flb_config *config,
                               NULL,      /* ca_file */
                               NULL,      /* crt_file */
                               NULL,      /* key_file */
-                              NULL);     /* key_passwd */
+                              NULL,      /* key_passwd */
+                              NULL);     /* openssl_provider */
     if (!ctx->tls) {
         flb_error("[oauth2] error initializing TLS context");
         goto error;

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -174,6 +174,9 @@ static void flb_output_free_properties(struct flb_output_instance *ins)
     if (ins->tls_ciphers) {
         flb_sds_destroy(ins->tls_ciphers);
     }
+    if (ins->tls_provider_query) {
+        flb_sds_destroy(ins->tls_provider_query);
+    }
 #endif
 }
 
@@ -751,6 +754,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->tls_crt_file          = NULL;
     instance->tls_key_file          = NULL;
     instance->tls_key_passwd        = NULL;
+    instance->tls_provider_query    = NULL;
 #endif
 
     if (plugin->flags & FLB_OUTPUT_NET) {
@@ -974,6 +978,9 @@ int flb_output_set_property(struct flb_output_instance *ins,
     }
     else if (prop_key_check("tls.ciphers", k, len) == 0) {
         flb_utils_set_plugin_string_property("tls.ciphers", &ins->tls_ciphers, tmp);
+    }
+    else if (prop_key_check("tls.provider_query", k, len) == 0) {
+        flb_utils_set_plugin_string_property("tls.provider_query", &ins->tls_provider_query, tmp);
     }
 #endif
     else if (prop_key_check("storage.total_limit_size", k, len) == 0 && tmp) {
@@ -1322,7 +1329,8 @@ int flb_output_init_all(struct flb_config *config)
                                       ins->tls_ca_file,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
-                                      ins->tls_key_passwd);
+                                      ins->tls_key_passwd,
+                                      ins->tls_provider_query);
             if (!ins->tls) {
                 flb_error("[output %s] error initializing TLS context",
                           ins->name);

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -153,6 +153,7 @@ static struct flb_upstream_node *create_node(int id,
     char *tls_crt_file = NULL;
     char *tls_key_file = NULL;
     char *tls_key_passwd = NULL;
+    char *tls_provider_query = NULL;
     flb_sds_t translated_value;
     struct cfl_list *head;
     struct cfl_kvpair *entry;
@@ -161,7 +162,7 @@ static struct flb_upstream_node *create_node(int id,
                                 "tls", "tls.vhost", "tls.verify", "tls.debug",
                                 "tls.ca_path", "tls.ca_file", "tls.crt_file",
                                 "tls.key_file", "tls.key_passwd",
-                                "tls.verify_hostname", NULL};
+                                "tls.verify_hostname", "tls.provider_query", NULL};
 
     struct flb_upstream_node *node;
 
@@ -235,6 +236,8 @@ static struct flb_upstream_node *create_node(int id,
     /* tls.key_file */
     tls_key_passwd = flb_cf_section_property_get_string(cf, s, "tls.key_passwd");
 
+    tls_provider_query = flb_cf_section_property_get_string(cf, s, "tls.provider_query");
+
     translate_environment_variables((flb_sds_t *) &name, config, FLB_TRUE);
     translate_environment_variables((flb_sds_t *) &host, config, FLB_TRUE);
     translate_environment_variables((flb_sds_t *) &port, config, FLB_TRUE);
@@ -244,6 +247,7 @@ static struct flb_upstream_node *create_node(int id,
     translate_environment_variables((flb_sds_t *) &tls_crt_file, config, FLB_TRUE);
     translate_environment_variables((flb_sds_t *) &tls_key_file, config, FLB_TRUE);
     translate_environment_variables((flb_sds_t *) &tls_key_passwd, config, FLB_TRUE);
+    translate_environment_variables((flb_sds_t *) &tls_provider_query, config, FLB_TRUE);
 
     /*
      * Create hash table to store unknown key/values that might be used
@@ -322,7 +326,7 @@ static struct flb_upstream_node *create_node(int id,
                                     tls_verify_hostname,
                                     tls_debug, tls_vhost, tls_ca_path, tls_ca_file,
                                     tls_crt_file, tls_key_file,
-                                    tls_key_passwd, ht, config);
+                                    tls_key_passwd, tls_provider_query, ht, config);
 
     /* Teardown for created flb_sds_t stuffs by flb_cf_section_property_get_string(). */
     if (tls_vhost != NULL) {
@@ -347,6 +351,10 @@ static struct flb_upstream_node *create_node(int id,
 
     if (tls_key_passwd != NULL) {
         flb_sds_destroy(tls_key_passwd);
+    }
+
+    if (tls_provider_query != NULL) {
+        flb_sds_destroy(tls_provider_query);
     }
 
     return node;

--- a/src/flb_upstream_node.c
+++ b/src/flb_upstream_node.c
@@ -38,6 +38,7 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
                                                    const char *tls_crt_file,
                                                    const char *tls_key_file,
                                                    const char *tls_key_passwd,
+                                                   const char* tls_provider_query,
                                                    struct flb_hash_table *ht,
                                                    struct flb_config *config)
 {
@@ -121,6 +122,12 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
         flb_upstream_node_destroy(node);
         return NULL;
     }
+
+    node->tls_provider_query = flb_sds_create(tls_provider_query);
+    if (!node->tls_provider_query) {
+        flb_upstream_node_destroy(node);
+        return NULL;
+    }
 #endif
 
     /* hash table */
@@ -137,7 +144,8 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
                                    tls_ca_file,
                                    tls_crt_file,
                                    tls_key_file,
-                                   tls_key_passwd);
+                                   tls_key_passwd, 
+                                   tls_provider_query);
         if (!node->tls) {
             flb_error("[upstream_node] error initializing TLS context "
                       "on node '%s'", name);
@@ -215,6 +223,7 @@ void flb_upstream_node_destroy(struct flb_upstream_node *node)
     flb_sds_destroy(node->tls_crt_file);
     flb_sds_destroy(node->tls_key_file);
     flb_sds_destroy(node->tls_key_passwd);
+    flb_sds_destroy(node->tls_provider_query);
     if (node->tls) {
         flb_tls_destroy(node->tls);
     }

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -98,6 +98,12 @@ struct flb_config_map tls_configmap[] = {
      "Specify TLS ciphers up to TLSv1.2"
     },
 
+    {
+     FLB_CONFIG_MAP_STR, "tls.provider_query", NULL,
+     0, FLB_FALSE, 0,
+     "OpenSSL Provider Query to use for TLS operations"
+     },
+
     /* EOF */
     {0}
 };
@@ -188,7 +194,8 @@ struct flb_tls *flb_tls_create(int mode,
                                const char *ca_file,
                                const char *crt_file,
                                const char *key_file,
-                               const char *key_passwd)
+                               const char *key_passwd,
+                               const char *additional_data)
 {
     void *backend;
     struct flb_tls *tls;
@@ -199,7 +206,8 @@ struct flb_tls *flb_tls_create(int mode,
 
     backend = tls_context_create(verify, debug, mode,
                                  vhost, ca_path, ca_file,
-                                 crt_file, key_file, key_passwd);
+                                 crt_file, key_file, key_passwd,
+                                 additional_data);
     if (!backend) {
         flb_error("[tls] could not create TLS backend");
         return NULL;
@@ -251,6 +259,14 @@ int flb_tls_init()
     return tls_init();
 }
 
+void flb_tls_configure(struct flb_config* config)
+{
+    if (!config) {
+        return;
+    }
+    tls_configure(config);
+}
+
 int flb_tls_destroy(struct flb_tls *tls)
 {
     if (tls->ctx) {
@@ -264,6 +280,11 @@ int flb_tls_destroy(struct flb_tls *tls)
     flb_free(tls);
 
     return 0;
+}
+
+void flb_tls_cleanup(void)
+{
+    tls_cleanup();
 }
 
 int flb_tls_set_alpn(struct flb_tls *tls, const char *alpn)

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -17,6 +17,15 @@
  *  limitations under the License.
  */
 
+ /*
+  * OPENSSL_VERSION_NUMBER has the following semantics
+  *
+  *     0x010100000L   M = major  F = fix    S = status
+  *       MMNNFFPPS    N = minor  P = patch
+  */
+#define OPENSSL_1_1_0 0x010100000L
+#define OPENSSL_3_0   0x030000000L
+
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef FLB_USE_OPENSSL_STORE
@@ -33,9 +42,11 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_3_0
 #include <openssl/provider.h>
 #ifdef FLB_USE_OPENSSL_STORE
 #include <openssl/store.h>
+#endif
 #endif
 #include <openssl/x509v3.h>
 
@@ -50,20 +61,14 @@
             strtok_s(str, delimiter, context)
 #endif
 
-/*
- * OPENSSL_VERSION_NUMBER has the following semantics
- *
- *     0x010100000L   M = major  F = fix    S = status
- *       MMNNFFPPS    N = minor  P = patch
- */
-#define OPENSSL_1_1_0 0x010100000L
-#define OPENSSL_3_0   0x030000000L
 
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_3_0
 #define MAX_OPENSSL_PROVIDERS 4
 struct openssl_provider_support {
     int current_provider;
     OSSL_PROVIDER* provider[MAX_OPENSSL_PROVIDERS];
 };
+#endif
 
 /* OpenSSL library context */
 struct tls_context {
@@ -72,7 +77,7 @@ struct tls_context {
     int mode;
     char *alpn;
     pthread_mutex_t mutex;
-#ifdef FLB_USE_OPENSSL_STORE
+#if defined(FLB_USE_OPENSSL_STORE) && (OPENSSL_VERSION_NUMBER >= OPENSSL_3_0)
     X509 *store_cert;
     EVP_PKEY *store_pkey;
 #endif
@@ -86,8 +91,12 @@ struct tls_session {
     struct tls_context *parent;    /* parent struct tls_context ref */
 };
 
+
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_3_0
+
 /* List of providers to load and activate for OpenSSL */
 static struct openssl_provider_support openssl_providers;
+
 
 static void openssl_providers_reset(void) 
 {
@@ -166,6 +175,8 @@ static void openssl_load_provider(const char* provider)
     return;
 }
 
+#endif
+
 static int tls_init(void)
 {
     flb_idebug("[tls] init");
@@ -180,18 +191,23 @@ static int tls_init(void)
     SSL_load_error_strings();
     SSL_library_init();
 #endif
+    
 
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_3_0
     /* Initialise the Providers Struct */
     openssl_providers.current_provider = 0;
     for (int i = 0; i < MAX_OPENSSL_PROVIDERS; i++) {
         openssl_providers.provider[i] = NULL;
     }
+#endif
 
     return 0;
 }
 
 static void tls_configure(struct flb_config* config)
 {
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_3_0
+
     int ret;
     const char* delim = ";";
     char* provider_list;
@@ -200,7 +216,6 @@ static void tls_configure(struct flb_config* config)
     if (!config) {
         return;
     }
-#if OPENSSL_VERSION_NUMBER >= OPENSSL_3_0
 
     openssl_providers_reset(); /* Could be a reconfig - start from scratch */
 
@@ -221,7 +236,9 @@ static void tls_configure(struct flb_config* config)
 
 static void tls_cleanup(void)
 {
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_3_0
     openssl_providers_reset();
+#endif
 }
 
 static void tls_info_callback(const SSL *s, int where, int ret)
@@ -282,7 +299,7 @@ static void tls_context_destroy(void *ctx_backend)
 
     SSL_CTX_free(ctx->ctx);
 
-#ifdef FLB_USE_OPENSSL_STORE    
+#if defined(FLB_USE_OPENSSL_STORE) && (OPENSSL_VERSION_NUMBER >= OPENSSL_3_0)  
     if (ctx->store_cert != NULL) {
         X509_free(ctx->store_cert);
         ctx->store_cert = NULL;
@@ -911,7 +928,7 @@ static void *tls_context_create(int verify,
 
     /* crt_file */
     if (crt_file) {
-#ifdef FLB_USE_OPENSSL_STORE
+#if defined(FLB_USE_OPENSSL_STORE) && (OPENSSL_VERSION_NUMBER >= OPENSSL_3_0)
         /* Try and open this as a store item first */
         if (openssl_provider_get_item((void**)&ctx->store_cert, crt_file,
                                       provider_query, openssl_provider_get_certificate)) {
@@ -946,7 +963,7 @@ static void *tls_context_create(int verify,
             SSL_CTX_set_default_passwd_cb_userdata(ssl_ctx,
                                                    (void*)key_passwd);
         }
-#ifdef FLB_USE_OPENSSL_STORE
+#if defined(FLB_USE_OPENSSL_STORE) && (OPENSSL_VERSION_NUMBER >= OPENSSL_3_0)
         /* Try and open this as a store item if we had no key password */
         else if (openssl_provider_get_item((void**)&ctx->store_pkey, key_file,
                                            provider_query, openssl_provider_get_private_key)) {
@@ -970,7 +987,7 @@ static void *tls_context_create(int verify,
                 flb_error("[tls] key_file '%s' %lu: %s",
                            key_file, ERR_get_error(), err_buf);
             }
-#ifdef FLB_USE_OPENSSL_STORE
+#if defined(FLB_USE_OPENSSL_STORE) && (OPENSSL_VERSION_NUMBER >= OPENSSL_3_0)
         }
 #endif
 

--- a/tests/runtime/in_tcp.c
+++ b/tests/runtime/in_tcp.c
@@ -373,6 +373,7 @@ void flb_test_tcp_with_tls()
                          NULL,
                          NULL,
                          NULL,
+                         NULL,
                          NULL);
 
     TEST_CHECK(tls != NULL);

--- a/tests/runtime/out_tcp.c
+++ b/tests/runtime/out_tcp.c
@@ -330,6 +330,7 @@ void flb_test_tcp_with_tls()
                          NULL,
                          TLS_CERTIFICATE_FILENAME,
                          TLS_PRIVATE_KEY_FILENAME,
+                         NULL,
                          NULL);
 
     TEST_CHECK(tls != NULL);


### PR DESCRIPTION
Added support for loading OpenSSL Providers. Up to 4 Providers that are defined in the OpenSSL configuration file can be activated by specifying the name in the new configuration option. This isn't specific to TLS, and can be used in general to load Providers for specific functionality.

Added a new compile time option to support the OpenSSL Store API (FLB_OPENSSL_STORE). This will enable treating the TLS crt_file and key_file options as Store URIs. There is also the ability to define a Provider Query to further help with utilising Providers in this scenario. With this ability it becomes possible to load the TLS artifacts from an HSM.

Enter [N/A] in the box, if an item is not applicable to your change.

Testing
Before we can approve your change; please submit the following in a comment:

[✅] Example configuration file for the change
```
service:
  log_level: debug
  openssl.providers: c7000

pipeline:
  inputs:
    - name: dummy
      dummy: '{"message": "Hello Joe"}'
 
  outputs:
    - name: opentelemetry
      match: '*'
      host: '192.168.8.1'
      port: 8909
      metrics_uri: /v1/metrics
      logs_uri: /v1/logs
      traces_uri: /v1/traces
      log_response_payload: true
      tls: on
      tls.verify: off
      tls.crt_file: 'GGL-STORE://type=cert;alias=dsscert'
      tls.key_file: 'GGL-STORE://type=priv;alias=dsskeyecc'
      tls.provider_query: '-fips, ?provider=gallagher' 
```
[✅] Debug log output from testing the change
```
Fluent Bit v4.0.2
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io
 
______ _                  _    ______ _ _             ___  _____
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/
 
 
[2025/07/18 10:33:27] [ info] Configuration:
[2025/07/18 10:33:27] [ info]  flush time     | 1.000000 seconds
[2025/07/18 10:33:27] [ info]  grace          | 5 seconds
[2025/07/18 10:33:27] [ info]  daemon         | 0
[2025/07/18 10:33:27] [ info] ___________
[2025/07/18 10:33:27] [ info]  inputs:
[2025/07/18 10:33:27] [ info]      tail
[2025/07/18 10:33:27] [ info]      tail
[2025/07/18 10:33:27] [ info]      tail
[2025/07/18 10:33:27] [ info] ___________
[2025/07/18 10:33:27] [ info]  filters:
[2025/07/18 10:33:27] [ info] ___________
[2025/07/18 10:33:27] [ info]  outputs:
[2025/07/18 10:33:27] [ info]      opentelemetry.0
[2025/07/18 10:33:27] [ info] ___________
[2025/07/18 10:33:27] [ info]  collectors:
[2025/07/18 10:33:27] [debug] [tls] init
[2025/07/18 10:33:27] [debug] [tls] resetting providers
[2025/07/18 10:33:27] [debug] [tls] loading provider 'c7000'
[2025/07/18 10:33:28] [ info] [fluent bit] version=4.0.2, commit=47cf86504b, pid=592
[2025/07/18 10:33:28] [debug] [engine] coroutine stack size: 196608 bytes (192.0K)
[2025/07/18 10:33:28] [ info] [storage] ver=1.5.3, type=memory+filesystem, sync=full, checksum=off, max_chunks_up=128
[2025/07/18 10:33:28] [ info] [storage] backlog input plugin: storage_backlog.3
[2025/07/18 10:33:28] [ info] [simd    ] disabled
[2025/07/18 10:33:28] [ info] [cmetrics] version=1.0.2
[2025/07/18 10:33:28] [ info] [ctraces ] version=0.6.6
[2025/07/18 10:33:28] [ info] [input:tail:tail.0] initializing
[2025/07/18 10:33:28] [ info] [input:tail:tail.0] storage_strategy='filesystem' (memory + filesystem)
...
[2025/07/18 10:33:28] [debug] [tls] Loading store item; query: -fips, ?provider=gallagher, uri: GGL-STORE://type=cert;alias=dss                                                                                                              cert, arg: (nil)
[2025/07/18 10:33:28] [debug] [tls] Loading store item; query: -fips, ?provider=gallagher, uri: GGL-STORE://type=priv;alias=dss 
```
This was tested on an embedded device, running an i.mx8 Processor with an EdgeLock chip for Secure World access.

[❌] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

[❌] Run [local packaging test](https://github.com/fluent/fluent-bit/pull/packaging/local-build-all.sh) showing all targets (including any new ones) build.
[❌] Set ok-package-test label to test for all targets (requires maintainer to do).