### PR TITLE
Extend TLS verification with new tls_verifier plugin type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,6 +710,7 @@ if(FLB_TLS)
   find_package(OpenSSL)
   if(OPENSSL_FOUND)
     FLB_DEFINITION(FLB_HAVE_OPENSSL)
+    include_directories(${OPENSSL_INCLUDE_DIR})
   endif()
 
   if (FLB_SYSTEM_WINDOWS AND NOT(OPENSSL_FOUND))

--- a/include/fluent-bit/config_format/flb_cf.h
+++ b/include/fluent-bit/config_format/flb_cf.h
@@ -60,6 +60,7 @@ enum section_type {
     FLB_CF_PLUGINS,               /* plugins             */
     FLB_CF_UPSTREAM_SERVERS,      /* upstream_servers    */
     FLB_CF_CUSTOM,                /* [CUSTOM]            */
+    FLB_CF_TLS_VERIFIER,          /* [TLS_VERIFIER]      */
     FLB_CF_INPUT,                 /* [INPUT]             */
     FLB_CF_FILTER,                /* [FILTER]            */
     FLB_CF_OUTPUT,                /* [OUTPUT]            */
@@ -111,6 +112,9 @@ struct flb_cf {
 
     /* 'custom' type plugins */
     struct mk_list customs;
+
+    /* 'tls_verifier' type plugins */
+    struct mk_list tls_verifiers;
 
     /* pipeline */
     struct mk_list inputs;

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -134,6 +134,7 @@ struct flb_config {
     struct mk_list parser_plugins;      /* not yet implemented */
     struct mk_list filter_plugins;
     struct mk_list out_plugins;
+    struct mk_list tls_verifier_plugins;
 
     /* Custom instances */
     struct mk_list customs;
@@ -152,6 +153,9 @@ struct flb_config {
 
     /* Filter instances */
     struct mk_list filters;
+
+    /* TLS Verifier instances */
+    struct mk_list tls_verifiers;
 
     struct mk_event_loop *evl;          /* the event loop (mk_core) */
 

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -449,6 +449,7 @@ struct flb_input_instance {
     char *tls_max_version;               /* Maximum protocol version of TLS */
     char *tls_ciphers;                   /* TLS ciphers */
     char *tls_provider_query;            /* OpenSSL Provider Query */
+    char *tls_verifier;                  /* TLS Verifier Plugin alias */
 
     struct mk_list *tls_config_map;
 

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -370,6 +370,7 @@ struct flb_output_instance {
     char *tls_max_version;               /* Maximum protocol version of TLS */
     char *tls_ciphers;                   /* TLS ciphers */
     char *tls_provider_query;            /* OpenSSL Provider Query */
+    char *tls_verifier;                  /* TLS Verifier plugin alias */
 #endif
 
     /*

--- a/include/fluent-bit/flb_plugin.h
+++ b/include/fluent-bit/flb_plugin.h
@@ -28,6 +28,7 @@
 #define FLB_PLUGIN_FILTER    2
 #define FLB_PLUGIN_OUTPUT    3
 #define FLB_PLUGIN_PROCESSOR 4
+#define FLB_PLUGIN_TLS_VERIFIER 5
 
 /* Informational contexts for discovered dynamic plugins */
 struct flb_plugin {
@@ -42,6 +43,7 @@ struct flb_plugins {
     struct mk_list processor;
     struct mk_list filter;
     struct mk_list output;
+    struct mk_list tls_verifier;
 };
 
 struct flb_plugins *flb_plugin_create();

--- a/include/fluent-bit/flb_plugins.h.in
+++ b/include/fluent-bit/flb_plugins.h.in
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_tls_verifier.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_log.h>
 
@@ -34,6 +35,7 @@ extern struct flb_output_plugin *flb_zig_native_output_plugin_init(void *);
 @FLB_OUT_PLUGINS_DECL@
 @FLB_FILTER_PLUGINS_DECL@
 @FLB_PROCESSOR_PLUGINS_DECL@
+@FLB_TLS_VERIFIER_PLUGINS_DECL@
 
 int flb_plugins_register(struct flb_config *config)
 {
@@ -42,12 +44,14 @@ int flb_plugins_register(struct flb_config *config)
     struct flb_output_plugin *out;
     struct flb_filter_plugin *filter;
     struct flb_processor_plugin *processor;
+    struct flb_tls_verifier_plugin *tls_verifier;
 
 @FLB_CUSTOM_PLUGINS_ADD@
 @FLB_IN_PLUGINS_ADD@
 @FLB_OUT_PLUGINS_ADD@
 @FLB_FILTER_PLUGINS_ADD@
 @FLB_PROCESSOR_PLUGINS_ADD@
+@FLB_TLS_VERIFIER_PLUGINS_ADD@
 
     return 0;
 }
@@ -61,6 +65,7 @@ void flb_plugins_unregister(struct flb_config *config)
     struct flb_output_plugin *out;
     struct flb_filter_plugin *filter;
     struct flb_processor_plugin *processor;
+    struct flb_tls_verifier_plugin *tls_verifier;
 
     mk_list_foreach_safe(head, tmp, &config->custom_plugins) {
         custom = mk_list_entry(head, struct flb_custom_plugin, _head);
@@ -96,6 +101,12 @@ void flb_plugins_unregister(struct flb_config *config)
         processor = mk_list_entry(head, struct flb_processor_plugin, _head);
         mk_list_del(&processor->_head);
         flb_free(processor);
+    }
+
+    mk_list_foreach_safe(head, tmp, &config->tls_verifier_plugins) {
+        tls_verifier = mk_list_entry(head, struct flb_tls_verifier_plugin, _head);
+        mk_list_del(&tls_verifier->_head);
+        flb_free(tls_verifier);
     }
 }
 

--- a/include/fluent-bit/flb_tls_verifier.h
+++ b/include/fluent-bit/flb_tls_verifier.h
@@ -1,0 +1,88 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_TLS_VERIFIER_H
+#define FLB_TLS_VERIFIER_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
+
+#include <openssl/types.h>
+
+struct flb_tls_verifier_instance;
+
+struct flb_tls_verifier_plugin {
+    char *name;            /* Name                               */
+    char *description;     /* Description                        */
+
+    /* Config map */
+    struct flb_config_map *config_map;
+
+    /* Callbacks */
+    int (*cb_init) (struct flb_tls_verifier_instance *, struct flb_config *);
+    int (*cb_verify) (int, X509_STORE_CTX *);
+    int (*cb_exit) (void *, struct flb_config *);
+
+    struct mk_list _head;  /* Link to parent list (config->tls_verifier_plugins) */
+};
+
+/*
+ * Each initialized plugin must have an instance, the same plugin may be
+ * loaded more than one time.
+ *
+ * An instance will contain basic fixed plugin data while also
+ * allowing for plugin context data, generated when the plugin is invoked.
+ */
+struct flb_tls_verifier_instance {
+    int id;                                 /* instance id              */
+    int log_level;                          /* instance log level       */
+    char name[32];                          /* numbered name            */
+    char *alias;                            /* alias name               */
+    void *context;                          /* Instance local context   */
+    struct flb_tls_verifier_plugin *plugin; /* original plugin          */
+
+    struct mk_list properties;              /* config properties        */
+    struct mk_list *config_map;             /* configuration map        */
+
+    /* Keep a reference to the original context this instance belongs to */
+    const struct flb_config *config;
+
+    struct mk_list _head;                   /* link to config->tls_verifiers  */
+};
+
+struct flb_tls_verifier_instance *flb_tls_verifier_new(struct flb_config *config,
+                                                       const char *name);
+
+const char *flb_tls_verifier_get_alias(struct flb_tls_verifier_instance *ins);
+
+int flb_tls_verifier_set_property(struct flb_tls_verifier_instance *ins,
+                                  const char *k, const char *v);
+int flb_tls_verifier_plugin_property_check(struct flb_tls_verifier_instance *ins,
+                                           struct flb_config *config);
+int flb_tls_verifier_init_all(struct flb_config *config);
+void flb_tls_verifier_exit(struct flb_config *config);
+
+void flb_tls_verifier_instance_destroy(struct flb_tls_verifier_instance *ins);
+
+const struct flb_tls_verifier_instance *find_tls_verifier_instance(
+                struct flb_config *config,
+                const char* alias);
+
+#endif

--- a/include/fluent-bit/flb_tls_verifier.h
+++ b/include/fluent-bit/flb_tls_verifier.h
@@ -26,6 +26,8 @@
 
 #include <openssl/types.h>
 
+#define FLB_X509_STORE_EX_INDEX 0
+
 struct flb_tls_verifier_instance;
 
 struct flb_tls_verifier_plugin {

--- a/include/fluent-bit/flb_tls_verifier_plugin.h
+++ b/include/fluent-bit/flb_tls_verifier_plugin.h
@@ -1,0 +1,47 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_TLS_VERIFIER_PLUGIN_H
+#define FLB_TLS_VERIFIER_PLUGIN_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_tls_verifier.h>
+#include <fluent-bit/flb_log.h>
+
+#define flb_plg_log(ctx, level, fmt, ...)                                \
+    if (flb_log_check_level(ctx->log_level, level))                      \
+        flb_log_print(level, NULL, 0, "[tls_verifier:%s:%s] " fmt,       \
+                      ctx->plugin->name,                                 \
+                      flb_tls_verifier_get_alias(ctx), ##__VA_ARGS__)
+
+#define flb_plg_error(ctx, fmt, ...) \
+    flb_plg_log(ctx, FLB_LOG_ERROR, fmt, ##__VA_ARGS__)
+
+#define flb_plg_warn(ctx, fmt, ...)  \
+    flb_plg_log(ctx, FLB_LOG_WARN, fmt, ##__VA_ARGS__)
+
+#define flb_plg_info(ctx, fmt, ...)  \
+    flb_plg_log(ctx, FLB_LOG_INFO, fmt, ##__VA_ARGS__)
+
+#define flb_plg_debug(ctx, fmt, ...) \
+    flb_plg_log(ctx, FLB_LOG_DEBUG, fmt, ##__VA_ARGS__)
+
+#define flb_plg_trace(ctx, fmt, ...) \
+    flb_plg_log(ctx, FLB_LOG_TRACE, fmt, ##__VA_ARGS__)
+#endif

--- a/include/fluent-bit/flb_upstream_node.h
+++ b/include/fluent-bit/flb_upstream_node.h
@@ -44,6 +44,7 @@ struct flb_upstream_node {
     char *tls_key_file;       /* Cert Key                     */
     char *tls_key_passwd;     /* Cert Key Password            */
     char *tls_provider_query; /* OpenSSL Provider Query       */
+    char *tls_verifier;       /* TLS Verifier plugin alias    */
 
     /* context with mbedTLS contexts and data */
     struct flb_tls *tls;
@@ -76,6 +77,7 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
                                                    const char *tls_key_file,
                                                    const char *tls_key_passwd,
                                                    const char *tls_provider_query,
+                                                   const char *tls_verifier,
                                                    struct flb_hash_table *ht,
                                                    struct flb_config *config);
 const char *flb_upstream_node_get_property(const char *prop,

--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -25,6 +25,8 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_coro.h>
+#include <fluent-bit/flb_tls_verifier.h>
+
 #include <stddef.h>
 
 #define FLB_TLS_ALPN_MAX_LENGTH 16
@@ -70,7 +72,8 @@ struct flb_tls_backend {
                              const char *, const char *,
                              const char *, const char *,
                              const char *, const char *,
-                             const char *);
+                             const char *,
+                             const struct flb_tls_verifier_instance *);
 
     /* destroy backend context */
     void (*context_destroy) (void *);
@@ -120,7 +123,8 @@ struct flb_tls *flb_tls_create(int mode,
                                const char *ca_path,
                                const char *ca_file, const char *crt_file,
                                const char *key_file, const char *key_passwd,
-                               const char *additional_data);
+                               const char *additional_data,
+                               const struct flb_tls_verifier_instance *tls_ins);
 
 int flb_tls_destroy(struct flb_tls *tls);
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -36,6 +36,43 @@ macro(REGISTER_CUSTOM_PLUGIN name)
   endif()
 endmacro()
 
+
+# REGISTER_TLS_VERIFIER_PLUGIN
+macro(REGISTER_TLS_VERIFIER_PLUGIN name)
+  string(FIND ${name} "=" pos)
+  if(pos GREATER -1)
+    string(REPLACE "=" ";" list ${name})
+    list(GET list 0 p_name)
+    list(GET list 1 p_path)
+    message(STATUS "EXTERNAL TLS_VERIFIER PLUGIN name='${p_name}' path='${p_path}'")
+  else()
+    set(p_name ${name})
+  endif()
+
+  string(TOUPPER ${p_name} NAME)
+  if(FLB_${NAME} OR p_path)
+    set(FLB_TLS_VERIFIER_PLUGINS_DECL "${FLB_TLS_VERIFIER_PLUGINS_DECL}extern struct flb_tls_verifier_plugin ${p_name}_plugin;\n")
+
+    # C code
+    set(C_CODE          "    tls_verifier = flb_malloc(sizeof(struct flb_tls_verifier_plugin));\n")
+    set(C_CODE "${C_CODE}    if (!tls_verifier) {\n")
+    set(C_CODE "${C_CODE}        flb_errno();\n")
+    set(C_CODE "${C_CODE}        return -1;\n")
+    set(C_CODE "${C_CODE}    }\n")
+    set(C_CODE "${C_CODE}    memcpy(tls_verifier, &${p_name}_plugin, sizeof(struct flb_tls_verifier_plugin));\n")
+    set(C_CODE "${C_CODE}    mk_list_add(&tls_verifier->_head, &config->tls_verifier_plugins);\n\n")
+
+    set(FLB_TLS_VERIFIER_PLUGINS_ADD "${FLB_TLS_VERIFIER_PLUGINS_ADD}${C_CODE}")
+
+    if (p_path)
+      add_subdirectory(${p_path} ${p_path})
+    else()
+      add_subdirectory(${p_name})
+    endif()
+    set(flb_plugins "${flb_plugins}flb-plugin-${p_name};")
+  endif()
+endmacro()
+
 # REGISTER_IN_PLUGIN
 macro(REGISTER_IN_PLUGIN name)
   string(FIND ${name} "=" pos)

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -1741,7 +1741,9 @@ static int flb_kubelet_network_init(struct flb_kube *ctx, struct flb_config *con
                                 ctx->tls_vhost,
                                 ctx->tls_ca_path,
                                 ctx->tls_ca_file,
-                                NULL, NULL, NULL, NULL);
+                                NULL, NULL,
+                                NULL, NULL,
+                                NULL);
         if (!ctx->kubelet_tls) {
             return -1;
         }
@@ -1794,7 +1796,9 @@ static int flb_kube_network_init(struct flb_kube *ctx, struct flb_config *config
                                   ctx->tls_vhost,
                                   ctx->tls_ca_path,
                                   ctx->tls_ca_file,
-                                  NULL, NULL, NULL, NULL);
+                                  NULL, NULL,
+                                  NULL, NULL,
+                                  NULL);
         if (!ctx->tls) {
             return -1;
         }

--- a/plugins/filter_nightfall/nightfall.c
+++ b/plugins/filter_nightfall/nightfall.c
@@ -96,8 +96,8 @@ static int cb_nightfall_init(struct flb_filter_instance *f_ins,
                               ctx->tls_debug,
                               ctx->tls_vhost,
                               ctx->tls_ca_path,
-                              NULL,
-                              NULL, NULL, NULL, NULL);
+                              NULL, NULL, NULL,
+                              NULL, NULL, NULL);
     if (!ctx->tls) {
         flb_plg_error(f_ins, "tls initialization error");
         flb_free(ctx);

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.c
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.c
@@ -109,7 +109,9 @@ static int network_init(struct k8s_events *ctx, struct flb_config *config)
                                   ctx->tls_vhost,
                                   ctx->tls_ca_path,
                                   ctx->tls_ca_file,
-                                  NULL, NULL, NULL, NULL);
+                                  NULL, NULL,
+                                  NULL, NULL,
+                                  NULL);
         if (!ctx->tls) {
             return -1;
         }

--- a/plugins/out_azure_blob/azure_blob_conf.c
+++ b/plugins/out_azure_blob/azure_blob_conf.c
@@ -376,6 +376,7 @@ static int flb_azure_blob_apply_remote_configuration(struct flb_azure_blob *cont
                                  NULL,
                                  NULL,
                                  NULL,
+                                 NULL,
                                  NULL);
 
     if (tls_context == NULL) {

--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -89,7 +89,7 @@ static struct flb_upstream_node *flb_upstream_node_create_url(struct flb_azure_k
                         NULL, sds_host, sds_port, FLB_TRUE, ctx->ins->tls->verify,
                         ctx->ins->tls->verify_hostname,
                         ctx->ins->tls->debug, ctx->ins->tls->vhost, NULL, NULL, NULL,
-                        NULL, NULL, NULL, kv, config);
+                        NULL, NULL, NULL, NULL, kv, config);
 
                     if (!node) {
                         flb_plg_error(ctx->ins, "error creating resource upstream node");

--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -656,6 +656,7 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
     char *token;
     int io_flags = FLB_IO_TLS;
     struct flb_bigquery *ctx;
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
 
     /* Create config context */
     ctx = flb_bigquery_conf_create(ins, config);
@@ -686,6 +687,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
     }
 
     if (ctx->has_identity_federation) {
+        tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
+
         /* Configure AWS IMDS */
         ctx->aws_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                       FLB_TRUE,
@@ -696,7 +699,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
                                       ins->tls_key_passwd,
-                                      ins->tls_provider_query);
+                                      ins->tls_provider_query,
+                                      tls_ins);
 
         if (!ctx->aws_tls) {
             flb_plg_error(ctx->ins, "Failed to create TLS context");
@@ -736,7 +740,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                           ins->tls_crt_file,
                                           ins->tls_key_file,
                                           ins->tls_key_passwd,
-                                          ins->tls_provider_query);
+                                          ins->tls_provider_query,
+                                          tls_ins);
 
         if (!ctx->aws_sts_tls) {
             flb_plg_error(ctx->ins, "Failed to create TLS context");
@@ -768,7 +773,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                              ins->tls_crt_file,
                                              ins->tls_key_file,
                                              ins->tls_key_passwd,
-                                             ins->tls_provider_query);
+                                             ins->tls_provider_query,
+                                             tls_ins);
 
         if (!ctx->google_sts_tls) {
             flb_plg_error(ctx->ins, "Failed to create TLS context");
@@ -797,7 +803,8 @@ static int cb_bigquery_init(struct flb_output_instance *ins,
                                              ins->tls_crt_file,
                                              ins->tls_key_file,
                                              ins->tls_key_passwd,
-                                             ins->tls_provider_query);
+                                             ins->tls_provider_query,
+                                             tls_ins);
 
         if (!ctx->google_iam_tls) {
             flb_plg_error(ctx->ins, "Failed to create TLS context");

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -84,6 +84,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     struct flb_cloudwatch *ctx = NULL;
     int ret;
     flb_sds_t tmp_sds = NULL;
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
     (void) config;
     (void) data;
 
@@ -243,6 +244,7 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     }
 
     /* one tls instance for provider, one for cw client */
+    tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
     ctx->cred_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                    FLB_TRUE,
                                    ins->tls_debug,
@@ -252,7 +254,8 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                                    ins->tls_crt_file,
                                    ins->tls_key_file,
                                    ins->tls_key_passwd,
-                                   ins->tls_provider_query);
+                                   ins->tls_provider_query,
+                                   tls_ins);
 
     if (!ctx->cred_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
@@ -268,7 +271,8 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                                      ins->tls_crt_file,
                                      ins->tls_key_file,
                                      ins->tls_key_passwd,
-                                     ins->tls_provider_query);
+                                     ins->tls_provider_query,
+                                     tls_ins);
     if (!ctx->client_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
         goto error;
@@ -305,7 +309,8 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
                                       ins->tls_key_passwd,
-                                      ins->tls_provider_query);
+                                      ins->tls_provider_query,
+                                      tls_ins);
         if (!ctx->sts_tls) {
             flb_errno();
             goto error;

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -150,6 +150,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     struct flb_uri_field *f_type = NULL;
     struct flb_upstream *upstream;
     struct flb_elasticsearch *ctx;
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
 
     /* Allocate context */
     ctx = flb_calloc(1, sizeof(struct flb_elasticsearch));
@@ -373,6 +374,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
             ctx->has_aws_auth = FLB_TRUE;
             flb_debug("[out_es] Enabled AWS Auth");
 
+            tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
             /* AWS provider needs a separate TLS instance */
             ctx->aws_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                           FLB_TRUE,
@@ -383,7 +385,8 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                           ins->tls_crt_file,
                                           ins->tls_key_file,
                                           ins->tls_key_passwd,
-                                          ins->tls_provider_query);
+                                          ins->tls_provider_query,
+                                          tls_ins);
             if (!ctx->aws_tls) {
                 flb_errno();
                 flb_es_conf_destroy(ctx);
@@ -445,7 +448,8 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                                   ins->tls_crt_file,
                                                   ins->tls_key_file,
                                                   ins->tls_key_passwd,
-                                                  ins->tls_provider_query);
+                                                  ins->tls_provider_query,
+                                                  tls_ins);
                 if (!ctx->aws_sts_tls) {
                     flb_errno();
                     flb_es_conf_destroy(ctx);

--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -58,6 +58,7 @@ static int cb_firehose_init(struct flb_output_instance *ins,
     char *session_name = NULL;
     struct flb_firehose *ctx = NULL;
     int ret;
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
     (void) config;
     (void) data;
 
@@ -148,6 +149,8 @@ static int cb_firehose_init(struct flb_output_instance *ins,
         ctx->role_arn = tmp;
     }
 
+    tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
+
     /* one tls instance for provider, one for cw client */
     ctx->cred_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                    FLB_TRUE,
@@ -158,7 +161,8 @@ static int cb_firehose_init(struct flb_output_instance *ins,
                                    ins->tls_crt_file,
                                    ins->tls_key_file,
                                    ins->tls_key_passwd,
-                                   ins->tls_provider_query);
+                                   ins->tls_provider_query,
+                                   tls_ins);
 
     if (!ctx->cred_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
@@ -174,7 +178,8 @@ static int cb_firehose_init(struct flb_output_instance *ins,
                                      ins->tls_crt_file,
                                      ins->tls_key_file,
                                      ins->tls_key_passwd,
-                                     ins->tls_provider_query);
+                                     ins->tls_provider_query,
+                                     tls_ins);
     if (!ctx->client_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
         goto error;
@@ -211,7 +216,8 @@ static int cb_firehose_init(struct flb_output_instance *ins,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
                                       ins->tls_key_passwd,
-                                      ins->tls_provider_query);
+                                      ins->tls_provider_query,
+                                      tls_ins);
         if (!ctx->sts_tls) {
             flb_errno();
             goto error;

--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -56,6 +56,7 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
     char *session_name = NULL;
     struct flb_kinesis *ctx = NULL;
     int ret;
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
     (void) config;
     (void) data;
 
@@ -160,6 +161,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
         ctx->role_arn = tmp;
     }
 
+    tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
+
     /* one tls instance for provider, one for cw client */
     ctx->cred_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                    FLB_TRUE,
@@ -170,7 +173,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                    ins->tls_crt_file,
                                    ins->tls_key_file,
                                    ins->tls_key_passwd, 
-                                   ins->tls_provider_query);
+                                   ins->tls_provider_query,
+                                   tls_ins);
 
     if (!ctx->cred_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
@@ -186,7 +190,8 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                      ins->tls_crt_file,
                                      ins->tls_key_file,
                                      ins->tls_key_passwd, 
-                                     ins->tls_provider_query);
+                                     ins->tls_provider_query,
+                                     tls_ins);
     if (!ctx->client_tls) {
         flb_plg_error(ctx->ins, "Failed to create tls context");
         goto error;
@@ -229,8 +234,10 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
                                       ins->tls_ca_file,
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
-                                      ins->tls_key_passwd, 
-                                      ins->tls_provider_query);
+                                      ins->tls_key_passwd,
+                                      ins->tls_provider_query,
+                                      tls_ins);
+
         if (!ctx->sts_tls) {
             flb_errno();
             goto error;

--- a/plugins/out_opensearch/os_conf.c
+++ b/plugins/out_opensearch/os_conf.c
@@ -47,6 +47,7 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
     struct flb_uri_field *f_type = NULL;
     struct flb_upstream *upstream;
     struct flb_opensearch *ctx;
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
 
     /* Allocate context */
     ctx = flb_calloc(1, sizeof(struct flb_opensearch));
@@ -248,6 +249,7 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
             ctx->has_aws_auth = FLB_TRUE;
             flb_debug("[out_es] Enabled AWS Auth");
 
+            tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
             /* AWS provider needs a separate TLS instance */
             ctx->aws_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                           FLB_TRUE,
@@ -258,7 +260,8 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
                                           ins->tls_crt_file,
                                           ins->tls_key_file,
                                           ins->tls_key_passwd,
-                                          ins->tls_provider_query);
+                                          ins->tls_provider_query,
+                                          tls_ins);
             if (!ctx->aws_tls) {
                 flb_errno();
                 flb_os_conf_destroy(ctx);
@@ -320,7 +323,8 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
                                                   ins->tls_crt_file,
                                                   ins->tls_key_file,
                                                   ins->tls_key_passwd,
-                                                  ins->tls_provider_query);
+                                                  ins->tls_provider_query,
+                                                  tls_ins);
                 if (!ctx->aws_sts_tls) {
                     flb_errno();
                     flb_os_conf_destroy(ctx);

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -526,6 +526,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
     struct flb_split_entry *tok;
     struct mk_list *split;
     int list_size;
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
 
     ctx = flb_calloc(1, sizeof(struct flb_s3));
     if (!ctx) {
@@ -776,6 +777,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
         ctx->storage_class = (char *) tmp;
     }
 
+    tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
     if (ctx->insecure == FLB_FALSE) {
         ctx->client_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                          ins->tls_verify,
@@ -785,8 +787,9 @@ static int cb_s3_init(struct flb_output_instance *ins,
                                          ins->tls_ca_file,
                                          ins->tls_crt_file,
                                          ins->tls_key_file,
-                                         ins->tls_key_passwd, 
-                                         ins->tls_provider_query);
+                                         ins->tls_key_passwd,
+                                         ins->tls_provider_query,
+                                         tls_ins);
         if (!ctx->client_tls) {
             flb_plg_error(ctx->ins, "Failed to create tls context");
             return -1;
@@ -802,8 +805,9 @@ static int cb_s3_init(struct flb_output_instance *ins,
                                        ins->tls_ca_file,
                                        ins->tls_crt_file,
                                        ins->tls_key_file,
-                                       ins->tls_key_passwd, 
-                                       ins->tls_provider_query);
+                                       ins->tls_key_passwd,
+                                       ins->tls_provider_query,
+                                       tls_ins);
     if (!ctx->provider_tls) {
         flb_errno();
         return -1;
@@ -837,8 +841,9 @@ static int cb_s3_init(struct flb_output_instance *ins,
                                                ins->tls_ca_file,
                                                ins->tls_crt_file,
                                                ins->tls_key_file,
-                                               ins->tls_key_passwd, 
-                                               ins->tls_provider_query);
+                                               ins->tls_key_passwd,
+                                               ins->tls_provider_query,
+                                               tls_ins);
 
         if (!ctx->sts_provider_tls) {
             flb_errno();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,7 @@ if(FLB_TLS)
   # Register the TLS interface and functions
   set(src
     ${src}
+    flb_tls_verifier.c
     "tls/flb_tls.c"
     "flb_oauth2.c"
     )

--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -356,6 +356,8 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
     struct flb_tls *cred_tls = NULL;
     struct flb_tls *sts_tls = NULL;
 
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
+
     /* Config keys */
     key_prefix_len = strlen(config_key_prefix);
     key_max_len = key_prefix_len + 12; /* max length of
@@ -375,6 +377,7 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
     strcpy(config_key_profile + key_prefix_len, "profile");
 
     /* AWS provider needs a separate TLS instance */
+    tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
     cred_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                               FLB_TRUE,
                               ins->tls_debug,
@@ -384,7 +387,8 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
                               ins->tls_crt_file,
                               ins->tls_key_file,
                               ins->tls_key_passwd,
-                              ins->tls_provider_query);
+                              ins->tls_provider_query,
+                              tls_ins);
     if (!cred_tls) {
         flb_plg_error(ins, "Failed to create TLS instance for AWS Provider");
         flb_errno();
@@ -436,7 +440,8 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
                                  ins->tls_crt_file,
                                  ins->tls_key_file,
                                  ins->tls_key_passwd,
-                                 ins->tls_provider_query);
+                                 ins->tls_provider_query,
+                                 tls_ins);
         if (!sts_tls) {
             flb_plg_error(ins, "Failed to create TLS instance for AWS STS Credential "
                           "Provider");

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -53,6 +53,7 @@ enum section {
     SECTION_SERVICE,
     SECTION_PIPELINE,
     SECTION_CUSTOM,
+    SECTION_TLS_VERIFIERS,
     SECTION_INPUT,
     SECTION_FILTER,
     SECTION_OUTPUT,
@@ -72,6 +73,7 @@ static char *section_names[] = {
     "service",
     "pipeline",
     "custom",
+    "tls_verifiers",
     "input",
     "filter",
     "output",
@@ -124,6 +126,8 @@ enum state {
     STATE_OTHER,           /* any other unknown section */
 
     STATE_CUSTOM,          /* custom plugins */
+    STATE_TLS_VERIFIERS,   /* TLS verifiers plugins */
+
     STATE_PIPELINE,        /* pipeline groups customs inputs, filters and outputs */
 
     STATE_PLUGIN_INPUT,    /* input plugins section */
@@ -269,6 +273,8 @@ static char *state_str(enum state val)
         return "other";
     case STATE_CUSTOM:
         return "custom";
+    case STATE_TLS_VERIFIERS:
+        return "tls_verifiers";
     case STATE_PIPELINE:
         return "pipeline";
     case STATE_PLUGIN_INPUT:
@@ -331,6 +337,9 @@ static int add_section_type(struct flb_cf *conf, struct parser_state *state)
     }
     else if (state->section == SECTION_CUSTOM) {
         state->cf_section = flb_cf_section_create(conf, "customs", 0);
+    }
+    else if (state->section == SECTION_TLS_VERIFIERS) {
+        state->cf_section = flb_cf_section_create(conf, "tls_verifiers", 0);
     }
     else if (state->section == SECTION_PARSER) {
         state->cf_section = flb_cf_section_create(conf, "parser", 0);
@@ -1467,10 +1476,11 @@ static int consume_event(struct flb_cf *conf, struct local_ctx *ctx,
         break;
 
     /*
-     * 'customs'
+     * 'customs' & 'tls_verifiers'
      *  --------
      */
     case STATE_CUSTOM:
+    case STATE_TLS_VERIFIERS:
         switch (event->type) {
         case YAML_SEQUENCE_START_EVENT:
             break;
@@ -1498,7 +1508,7 @@ static int consume_event(struct flb_cf *conf, struct local_ctx *ctx,
             return YAML_FAILURE;
         }
         break;
-    /* end of 'customs' */
+    /* end of 'customs' & 'tls_verifiers' */
 
     case STATE_PIPELINE:
         switch (event->type) {
@@ -1616,6 +1626,16 @@ static int consume_event(struct flb_cf *conf, struct local_ctx *ctx,
             }
             else if (strcasecmp(value, "customs") == 0) {
                 state = state_push_section(ctx, STATE_CUSTOM, SECTION_CUSTOM);
+
+                if (state == NULL) {
+                    flb_error("unable to allocate state");
+                    return YAML_FAILURE;
+                }
+            }
+            else if (strcasecmp(value, "tls_verifiers") == 0) {
+                state = state_push_section(ctx,
+                                           STATE_TLS_VERIFIERS,
+                                           SECTION_TLS_VERIFIERS);
 
                 if (state == NULL) {
                     flb_error("unable to allocate state");

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -134,6 +134,9 @@ struct flb_cf *flb_cf_create()
     /* 'custom' type plugins */
     mk_list_init(&ctx->customs);
 
+    /* 'tls verifiers' type plugins */
+    mk_list_init(&ctx->tls_verifiers);
+
     /* pipeline */
     mk_list_init(&ctx->inputs);
     mk_list_init(&ctx->filters);
@@ -193,6 +196,10 @@ static enum section_type get_section_type(char *name, int len)
     else if (strncasecmp(name, "custom", len) == 0 ||
              strncasecmp(name, "customs", len) == 0) {
         return FLB_CF_CUSTOM;
+    }
+    else if (strncasecmp(name, "tls_verifier", len) == 0 ||
+             strncasecmp(name, "tls_verifiers", len) == 0) {
+        return FLB_CF_TLS_VERIFIER;
     }
     else if (strncasecmp(name, "input", len) == 0 ||
              strncasecmp(name, "inputs", len) == 0) {
@@ -667,6 +674,9 @@ struct flb_cf_section *flb_cf_section_create(struct flb_cf *cf, char *name, int 
     else if (type == FLB_CF_CUSTOM) {
         mk_list_add(&s->_head_section, &cf->customs);
     }
+    else if (type == FLB_CF_TLS_VERIFIER) {
+        mk_list_add(&s->_head_section, &cf->tls_verifiers);
+    }
     else if (type == FLB_CF_INPUT) {
         mk_list_add(&s->_head_section, &cf->inputs);
     }
@@ -766,6 +776,8 @@ static char *section_type_str(int type)
         return "UPSTREAM_SERVERS";
     case FLB_CF_CUSTOM:
         return "CUSTOM";
+    case FLB_CF_TLS_VERIFIER:
+        return "TLS_VERIFIER";
     case FLB_CF_INPUT:
         return "INPUT";
     case FLB_CF_FILTER:

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -336,11 +336,13 @@ struct flb_config *flb_config_init()
     /* Initialize linked lists */
     mk_list_init(&config->processor_plugins);
     mk_list_init(&config->custom_plugins);
+    mk_list_init(&config->tls_verifier_plugins);
     mk_list_init(&config->in_plugins);
     mk_list_init(&config->parser_plugins);
     mk_list_init(&config->filter_plugins);
     mk_list_init(&config->out_plugins);
     mk_list_init(&config->customs);
+    mk_list_init(&config->tls_verifiers);
     mk_list_init(&config->inputs);
     mk_list_init(&config->parsers);
     mk_list_init(&config->filters);
@@ -764,6 +766,10 @@ static int configure_plugins_type(struct flb_config *config, struct flb_cf *cf, 
         s_type = "custom";
         list = &cf->customs;
     }
+    else if (type == FLB_CF_TLS_VERIFIER) {
+        s_type = "tls_verifier";
+        list = &cf->tls_verifiers;
+    }
     else if (type == FLB_CF_INPUT) {
         s_type = "input";
         list = &cf->inputs;
@@ -796,6 +802,9 @@ static int configure_plugins_type(struct flb_config *config, struct flb_cf *cf, 
         ins = NULL;
         if (type == FLB_CF_CUSTOM) {
             ins = flb_custom_new(config, tmp, NULL);
+        }
+        else if (type == FLB_CF_TLS_VERIFIER) {
+            ins = flb_tls_verifier_new(config, tmp);
         }
         else if (type == FLB_CF_INPUT) {
             ins = flb_input_new(config, tmp, NULL, FLB_TRUE);
@@ -839,6 +848,20 @@ static int configure_plugins_type(struct flb_config *config, struct flb_cf *cf, 
                     for (i = 0; i < kv->val->data.as_array->entry_count; i++) {
                         val = kv->val->data.as_array->entries[i];
                         ret = flb_custom_set_property(ins, kv->key, val->data.as_string);
+                    }
+                }
+            }
+            else if (type == FLB_CF_TLS_VERIFIER) {
+                if (kv->val->type == CFL_VARIANT_STRING) {
+                    ret = flb_tls_verifier_set_property(ins,
+                                                        kv->key,
+                                                        kv->val->data.as_string);
+                } else if (kv->val->type == CFL_VARIANT_ARRAY) {
+                    for (i = 0; i < kv->val->data.as_array->entry_count; i++) {
+                        val = kv->val->data.as_array->entries[i];
+                        ret = flb_tls_verifier_set_property(ins,
+                                                            kv->key,
+                                                            val->data.as_string);
                     }
                 }
             }
@@ -936,6 +959,7 @@ int flb_config_load_config_format(struct flb_config *config, struct flb_cf *cf)
         if (strcasecmp(s->name, "env") == 0 ||
             strcasecmp(s->name, "service") == 0 ||
             strcasecmp(s->name, "custom") == 0 ||
+            strcasecmp(s->name, "tls_verifier") == 0 ||
             strcasecmp(s->name, "input") == 0 ||
             strcasecmp(s->name, "filter") == 0 ||
             strcasecmp(s->name, "output") == 0) {
@@ -994,7 +1018,10 @@ int flb_config_load_config_format(struct flb_config *config, struct flb_cf *cf)
     if (ret == -1) {
         return -1;
     }
-
+    ret = configure_plugins_type(config, cf, FLB_CF_TLS_VERIFIER);
+    if (ret == -1) {
+        return -1;
+    }
     ret = configure_plugins_type(config, cf, FLB_CF_INPUT);
     if (ret == -1) {
         return -1;

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -819,6 +819,12 @@ int flb_engine_start(struct flb_config *config)
         return -1;
     }
 
+    /* Initialize tls verifier plugins */
+    ret = flb_tls_verifier_init_all(config);
+    if (ret == -1) {
+        return -1;
+    }
+
     /* Start the Storage engine */
     ret = flb_storage_create(config);
     if (ret == -1) {
@@ -1173,6 +1179,7 @@ int flb_engine_shutdown(struct flb_config *config)
     flb_filter_exit(config);
     flb_output_exit(config);
     flb_custom_exit(config);
+    flb_tls_verifier_exit(config);
     flb_input_exit_all(config);
 
     /* scheduler */

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -392,6 +392,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->tls_key_file          = NULL;
         instance->tls_key_passwd        = NULL;
         instance->tls_provider_query    = NULL;
+        instance->tls_verifier          = NULL;
 #endif
 
         /* Plugin requires a co-routine context ? */
@@ -672,6 +673,9 @@ int flb_input_set_property(struct flb_input_instance *ins,
     else if (prop_key_check("tls.provider_query", k, len) == 0) {
         flb_utils_set_plugin_string_property("tls.provider_query", &ins->tls_provider_query, tmp);
     }
+    else if (prop_key_check("tls.tls_verifier", k, len) == 0) {
+        flb_utils_set_plugin_string_property("tls.tls_verifier", &ins->tls_verifier, tmp);
+    }
 #endif
     else if (prop_key_check("storage.type", k, len) == 0 && tmp) {
         /* Set the storage type */
@@ -832,6 +836,10 @@ void flb_input_instance_destroy(struct flb_input_instance *ins)
 
     if (ins->tls_provider_query) {
         flb_sds_destroy(ins->tls_provider_query);
+    }
+
+    if (ins->tls_verifier) {
+        flb_sds_destroy(ins->tls_verifier);
     }
 
     /* release the tag if any */
@@ -1060,6 +1068,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
     struct flb_config *ctx = ins->config;
     struct flb_input_plugin *p = ins->p;
     int tls_session_mode;
+    const struct flb_tls_verifier_instance *tls_ins = NULL;
 
     if (ins->log_level == -1 && config->log != NULL) {
         ins->log_level = config->log->level;
@@ -1242,6 +1251,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
             tls_session_mode = FLB_TLS_CLIENT_MODE;
         }
 
+        tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
         ins->tls = flb_tls_create(tls_session_mode,
                                   ins->tls_verify,
                                   ins->tls_debug,
@@ -1251,7 +1261,8 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                                   ins->tls_crt_file,
                                   ins->tls_key_file,
                                   ins->tls_key_passwd,
-                                  ins->tls_provider_query);
+                                  ins->tls_provider_query,
+                                  tls_ins);
 
         if (ins->tls == NULL) {
             flb_error("[input %s] error initializing TLS context",

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -221,7 +221,8 @@ struct flb_oauth2 *flb_oauth2_create(struct flb_config *config,
                               NULL,      /* crt_file */
                               NULL,      /* key_file */
                               NULL,      /* key_passwd */
-                              NULL);     /* openssl_provider */
+                              NULL,      /* openssl_provider */
+                              NULL);     /* verifier */
     if (!ctx->tls) {
         flb_error("[oauth2] error initializing TLS context");
         goto error;

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -755,6 +755,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->tls_key_file          = NULL;
     instance->tls_key_passwd        = NULL;
     instance->tls_provider_query    = NULL;
+    instance->tls_verifier          = NULL;
 #endif
 
     if (plugin->flags & FLB_OUTPUT_NET) {
@@ -982,6 +983,9 @@ int flb_output_set_property(struct flb_output_instance *ins,
     else if (prop_key_check("tls.provider_query", k, len) == 0) {
         flb_utils_set_plugin_string_property("tls.provider_query", &ins->tls_provider_query, tmp);
     }
+    else if (prop_key_check("tls.verifier", k, len) == 0 && tmp) {
+        flb_utils_set_plugin_string_property("tls.verifier", &ins->tls_verifier, tmp);
+    }
 #endif
     else if (prop_key_check("storage.total_limit_size", k, len) == 0 && tmp) {
         if (strcasecmp(tmp, "off") == 0 ||
@@ -1157,6 +1161,7 @@ int flb_output_init_all(struct flb_config *config)
     struct mk_list *head;
     struct flb_output_instance *ins;
     struct flb_output_plugin *p;
+    const struct flb_tls_verifier_instance *tls_ins;
     uint64_t ts;
 
     /* Retrieve the plugin reference */
@@ -1321,6 +1326,7 @@ int flb_output_init_all(struct flb_config *config)
 
 #ifdef FLB_HAVE_TLS
         if (ins->use_tls == FLB_TRUE) {
+            tls_ins = find_tls_verifier_instance(config, ins->tls_verifier);
             ins->tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                       ins->tls_verify,
                                       ins->tls_debug,
@@ -1330,7 +1336,8 @@ int flb_output_init_all(struct flb_config *config)
                                       ins->tls_crt_file,
                                       ins->tls_key_file,
                                       ins->tls_key_passwd,
-                                      ins->tls_provider_query);
+                                      ins->tls_provider_query,
+                                      tls_ins);
             if (!ins->tls) {
                 flb_error("[output %s] error initializing TLS context",
                           ins->name);

--- a/src/flb_plugin.c
+++ b/src/flb_plugin.c
@@ -77,6 +77,15 @@ static int is_output(char *name)
     return FLB_FALSE;
 }
 
+static int is_tls_verifier(char *name)
+{
+    if (strncmp(name, "tls_verifier_", 13) == 0) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
 static void *get_handle(const char *path)
 {
     void *handle;
@@ -155,7 +164,8 @@ static char *path_to_plugin_name(char *path)
     if (is_input(name) == FLB_FALSE &&
         is_processor(name) == FLB_FALSE &&
         is_filter(name) == FLB_FALSE &&
-        is_output(name) == FLB_FALSE) {
+        is_output(name) == FLB_FALSE &&
+        is_tls_verifier(name) == FLB_FALSE) {
         flb_error("[plugin] invalid plugin type: %s", name);
         flb_free(name);
         return NULL;
@@ -193,6 +203,7 @@ struct flb_plugins *flb_plugin_create()
     mk_list_init(&ctx->processor);
     mk_list_init(&ctx->filter);
     mk_list_init(&ctx->output);
+    mk_list_init(&ctx->tls_verifier);
 
     return ctx;
 }
@@ -209,6 +220,7 @@ int flb_plugin_load(char *path, struct flb_plugins *ctx,
     struct flb_processor_plugin *processor;
     struct flb_filter_plugin *filter;
     struct flb_output_plugin *output;
+    struct flb_tls_verifier_plugin *tls_verifier = NULL;
 
     /* Open the shared object file: dlopen(3) */
     dso_handle = get_handle(path);
@@ -286,6 +298,18 @@ int flb_plugin_load(char *path, struct flb_plugins *ctx,
         memcpy(output, symbol, sizeof(struct flb_output_plugin));
         mk_list_add(&output->_head, &config->out_plugins);
     }
+    else if (is_tls_verifier(plugin_stname) == FLB_TRUE) {
+        type = FLB_PLUGIN_TLS_VERIFIER;
+        tls_verifier = flb_malloc(sizeof(struct flb_tls_verifier_plugin));
+        if (!tls_verifier) {
+            flb_errno();
+            flb_free(plugin_stname);
+            dlclose(dso_handle);
+            return -1;
+        }
+        memcpy(tls_verifier, symbol, sizeof(struct flb_tls_verifier_plugin));
+        mk_list_add(&tls_verifier->_head, &config->tls_verifier_plugins);
+    }
     flb_free(plugin_stname);
 
     if (type == -1) {
@@ -318,6 +342,9 @@ int flb_plugin_load(char *path, struct flb_plugins *ctx,
     }
     else if (type == FLB_PLUGIN_OUTPUT) {
         mk_list_add(&plugin->_head, &ctx->output);
+    }
+    else if (type == FLB_PLUGIN_TLS_VERIFIER) {
+        mk_list_add(&plugin->_head, &ctx->tls_verifier);
     }
 
     return 0;
@@ -489,5 +516,9 @@ void flb_plugin_destroy(struct flb_plugins *ctx)
         destroy_plugin(plugin);
     }
 
+    mk_list_foreach_safe(head, tmp, &ctx->tls_verifier) {
+        plugin = mk_list_entry(head, struct flb_plugin, _head);
+        destroy_plugin(plugin);
+    }
     flb_free(ctx);
 }

--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -26,6 +26,7 @@
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_custom.h>
+#include <fluent-bit/flb_tls_verifier.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_config_format.h>
 #include <fluent-bit/flb_kv.h>
@@ -201,6 +202,32 @@ static int flb_custom_propery_check_all(struct flb_config *config)
     return 0;
 }
 
+static int flb_tls_verifier_property_check_all(struct flb_config *config)
+{
+    int ret;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_tls_verifier_instance *ins;
+
+    /* Iterate all active tls verifier instance plugins */
+    mk_list_foreach_safe(head, tmp, &config->tls_verifiers) {
+        ins = mk_list_entry(head, struct flb_tls_verifier_instance, _head);
+
+        /* Check plugin property */
+        ret = flb_tls_verifier_plugin_property_check(ins, config);
+        if (ret == -1) {
+            return -1;
+        }
+
+        /* destroy config map (will be recreated at flb_start) */
+        if (ins->config_map) {
+            flb_config_map_destroy(ins->config_map);
+            ins->config_map = NULL;
+        }
+    }
+    return 0;
+}
+
 int flb_reload_property_check_all(struct flb_config *config)
 {
     int ret = 0;
@@ -233,6 +260,14 @@ int flb_reload_property_check_all(struct flb_config *config)
     ret = flb_output_propery_check_all(config);
     if (ret == -1) {
         flb_error("[reload] check properties for output plugins is failed");
+
+        return -1;
+    }
+
+    /* Check properties of tls verifier plugins */
+    ret = flb_tls_verifier_property_check_all(config);
+    if (ret == -1) {
+        flb_error("[reload] check properties for tls verifier plugins has failed");
 
         return -1;
     }

--- a/src/flb_tls_verifier.c
+++ b/src/flb_tls_verifier.c
@@ -1,0 +1,304 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_tls_verifier.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_env.h>
+#include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_utils.h>
+
+static int instance_id(struct flb_config *config)
+{
+    struct flb_tls_verifier_instance *entry;
+
+    if (mk_list_size(&config->tls_verifiers) == 0) {
+        return 0;
+    }
+
+    entry = mk_list_entry_last(&config->tls_verifiers, struct flb_tls_verifier_instance,
+                               _head);
+    return (entry->id + 1);
+}
+
+const char *flb_tls_verifier_get_alias(struct flb_tls_verifier_instance *ins)
+{
+    if (ins->alias) {
+        return ins->alias;
+    }
+
+    return ins->name;
+}
+
+static int prop_key_check(const char *key, const char *kv, int k_len)
+{
+    int len = strlen(key);
+    if (strncasecmp(key, kv, k_len) == 0 && len == k_len) {
+        return 0;
+    }
+
+    return -1;
+}
+
+/* Initialize all tls verify plugins */
+int flb_tls_verifier_init_all(struct flb_config *config)
+{
+    int ret;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_tls_verifier_plugin *plugin;
+    struct flb_tls_verifier_instance *ins;
+
+    /* Iterate all active tls verify instance plugins */
+    mk_list_foreach_safe(head, tmp, &config->tls_verifiers) {
+        ins = mk_list_entry(head, struct flb_tls_verifier_instance, _head);
+
+        if (ins->log_level == -1) {
+            ins->log_level = config->log->level;
+        }
+
+        plugin = ins->plugin;
+
+        /*
+         * Before to call the initialization callback, make sure that the received
+         * configuration parameters are valid if the plugin is registering a config map.
+         */
+        if (flb_tls_verifier_plugin_property_check(ins, config) == -1) {
+            flb_tls_verifier_instance_destroy(ins);
+            return -1;
+        }
+
+        /* Initialize the input */
+        if (plugin->cb_init) {
+            ret = plugin->cb_init(ins, config);
+            if (ret != 0) {
+                flb_error("Failed initialize tls_verifier %s", ins->name);
+                flb_tls_verifier_instance_destroy(ins);
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+struct flb_tls_verifier_instance *flb_tls_verifier_new(struct flb_config *config,
+                                                       const char *name)
+{
+    int id;
+    struct mk_list *head;
+    struct flb_tls_verifier_plugin *plugin;
+    struct flb_tls_verifier_instance *instance = NULL;
+
+    if (!name) {
+        return NULL;
+    }
+
+    mk_list_foreach(head, &config->tls_verifier_plugins) {
+        plugin = mk_list_entry(head, struct flb_tls_verifier_plugin, _head);
+        if (strcmp(plugin->name, name) == 0) {
+            break;
+        }
+        plugin = NULL;
+    }
+
+    if (!plugin) {
+        return NULL;
+    }
+
+    instance = flb_calloc(1, sizeof(struct flb_tls_verifier_instance));
+    if (!instance) {
+        flb_errno();
+        return NULL;
+    }
+    instance->config = config;
+
+    /* Get an ID */
+    id =  instance_id(config);
+
+    /* format name (with instance id) */
+    snprintf(instance->name, sizeof(instance->name) - 1,
+             "%s.%i", plugin->name, id);
+
+    instance->id    = id;
+    instance->alias = NULL;
+    instance->plugin = plugin;
+    instance->log_level = -1;
+
+    mk_list_init(&instance->properties);
+    mk_list_add(&instance->_head, &config->tls_verifiers);
+
+    return instance;
+}
+
+/* Override a configuration property for the given input_instance plugin */
+int flb_tls_verifier_set_property(struct flb_tls_verifier_instance *ins,
+                                  const char *k, const char *v)
+{
+    int len;
+    int ret;
+    flb_sds_t tmp;
+    struct flb_kv *kv;
+    const struct flb_config *config = ins->config;
+
+    len = strlen(k);
+    tmp = flb_env_var_translate(config->env, v);
+    if (tmp) {
+        if (strlen(tmp) == 0) {
+            flb_sds_destroy(tmp);
+            tmp = NULL;
+        }
+    }
+
+    if (prop_key_check("alias", k, len) == 0 && tmp) {
+        flb_utils_set_plugin_string_property("alias", &ins->alias, tmp);
+    }
+    else if (prop_key_check("log_level", k, len) == 0 && tmp) {
+        ret = flb_log_get_level_str(tmp);
+        flb_sds_destroy(tmp);
+        if (ret == -1) {
+            return -1;
+        }
+        ins->log_level = ret;
+    }
+    else {
+        /*
+         * Create the property, we don't pass the value since we will
+         * map it directly to avoid an extra memory allocation.
+         */
+        kv = flb_kv_item_create(&ins->properties, (char *) k, NULL);
+        if (!kv) {
+            if (tmp) {
+                flb_sds_destroy(tmp);
+            }
+            return -1;
+        }
+        kv->val = tmp;
+    }
+
+    return 0;
+}
+
+int flb_tls_verifier_plugin_property_check(struct flb_tls_verifier_instance *ins,
+                                           struct flb_config *config)
+{
+    int ret = 0;
+    struct mk_list *config_map;
+    struct flb_tls_verifier_plugin *plugin = ins->plugin;
+
+    if (plugin->config_map) {
+        /*
+         * Create a dynamic version of the configmap that will be used by the specific
+         * instance in question.
+         */
+        config_map = flb_config_map_create(config, plugin->config_map);
+        if (!config_map) {
+            flb_error("[tls_verifier] error loading config map for '%s' plugin",
+                      plugin->name);
+            return -1;
+        }
+        ins->config_map = config_map;
+
+        if (!ins->alias || flb_sds_len(ins->alias) == 0) {
+            flb_error("[tls_verifier] NO alias property for %s tls_verifier instance.",
+                        ins->name);
+            return -1;
+        }
+
+        /* Validate incoming properties against config map */
+        ret = flb_config_map_properties_check(ins->plugin->name,
+                                              &ins->properties, ins->config_map);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+void flb_tls_verifier_instance_exit(struct flb_tls_verifier_instance *ins,
+                                    struct flb_config *config)
+{
+    struct flb_tls_verifier_plugin *plugin = ins->plugin;
+    if (plugin->cb_exit && ins->context) {
+        plugin->cb_exit(ins->context, config);
+    }
+}
+
+/* Invoke exit call for the tls_verifier plugin */
+void flb_tls_verifier_exit(struct flb_config *config)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_tls_verifier_instance *ins;
+    struct flb_tls_verifier_plugin *plugin;
+
+    mk_list_foreach_safe(head, tmp, &config->tls_verifiers) {
+        ins = mk_list_entry(head, struct flb_tls_verifier_instance, _head);
+        plugin = ins->plugin;
+        if (!plugin) {
+            continue;
+        }
+        flb_tls_verifier_instance_exit(ins, config);
+        flb_tls_verifier_instance_destroy(ins);
+    }
+}
+
+
+void flb_tls_verifier_instance_destroy(struct flb_tls_verifier_instance *ins)
+{
+    if (!ins) {
+        return;
+    }
+
+    /* destroy config map */
+    if (ins->config_map) {
+        flb_config_map_destroy(ins->config_map);
+    }
+
+    /* release properties */
+    flb_kv_release(&ins->properties);
+
+    if (ins->alias) {
+        flb_sds_destroy(ins->alias);
+    }
+
+    mk_list_del(&ins->_head);
+    flb_free(ins);
+}
+
+const struct flb_tls_verifier_instance *find_tls_verifier_instance(
+                struct flb_config *config,
+                const char* alias)
+{
+    struct mk_list *head;
+    struct flb_tls_verifier_instance *verifier;
+
+    if (!alias || strlen(alias) == 0) {
+        return NULL;
+    }
+
+    mk_list_foreach(head, &config->tls_verifiers) {
+        verifier = mk_list_entry(head, struct flb_tls_verifier_instance, _head);
+        if (strcmp(verifier->alias, alias) == 0) {
+            return verifier;
+        }
+    }
+
+    return NULL;
+}

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -154,6 +154,7 @@ static struct flb_upstream_node *create_node(int id,
     char *tls_key_file = NULL;
     char *tls_key_passwd = NULL;
     char *tls_provider_query = NULL;
+    char *tls_verifier = NULL;
     flb_sds_t translated_value;
     struct cfl_list *head;
     struct cfl_kvpair *entry;
@@ -162,7 +163,8 @@ static struct flb_upstream_node *create_node(int id,
                                 "tls", "tls.vhost", "tls.verify", "tls.debug",
                                 "tls.ca_path", "tls.ca_file", "tls.crt_file",
                                 "tls.key_file", "tls.key_passwd",
-                                "tls.verify_hostname", "tls.provider_query", NULL};
+                                "tls.verify_hostname", "tls.provider_query",
+                                "tls.tls_verifier", NULL};
 
     struct flb_upstream_node *node;
 
@@ -238,6 +240,8 @@ static struct flb_upstream_node *create_node(int id,
 
     tls_provider_query = flb_cf_section_property_get_string(cf, s, "tls.provider_query");
 
+    tls_verifier = flb_cf_section_property_get_string(cf, s, "tls.tls_verifier");
+
     translate_environment_variables((flb_sds_t *) &name, config, FLB_TRUE);
     translate_environment_variables((flb_sds_t *) &host, config, FLB_TRUE);
     translate_environment_variables((flb_sds_t *) &port, config, FLB_TRUE);
@@ -248,6 +252,7 @@ static struct flb_upstream_node *create_node(int id,
     translate_environment_variables((flb_sds_t *) &tls_key_file, config, FLB_TRUE);
     translate_environment_variables((flb_sds_t *) &tls_key_passwd, config, FLB_TRUE);
     translate_environment_variables((flb_sds_t *) &tls_provider_query, config, FLB_TRUE);
+    translate_environment_variables((flb_sds_t *) &tls_verifier, config, FLB_TRUE);
 
     /*
      * Create hash table to store unknown key/values that might be used
@@ -326,7 +331,8 @@ static struct flb_upstream_node *create_node(int id,
                                     tls_verify_hostname,
                                     tls_debug, tls_vhost, tls_ca_path, tls_ca_file,
                                     tls_crt_file, tls_key_file,
-                                    tls_key_passwd, tls_provider_query, ht, config);
+                                    tls_key_passwd, tls_provider_query,
+                                    tls_verifier, ht, config);
 
     /* Teardown for created flb_sds_t stuffs by flb_cf_section_property_get_string(). */
     if (tls_vhost != NULL) {
@@ -357,6 +363,9 @@ static struct flb_upstream_node *create_node(int id,
         flb_sds_destroy(tls_provider_query);
     }
 
+    if (tls_verifier != NULL) {
+        flb_sds_destroy(tls_verifier);
+    }
     return node;
 }
 

--- a/src/flb_upstream_node.c
+++ b/src/flb_upstream_node.c
@@ -39,6 +39,7 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
                                                    const char *tls_key_file,
                                                    const char *tls_key_passwd,
                                                    const char* tls_provider_query,
+                                                   const char *tls_verifier,
                                                    struct flb_hash_table *ht,
                                                    struct flb_config *config)
 {
@@ -47,6 +48,7 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
     int io_flags;
     char tmp[255];
     struct flb_upstream_node *node;
+    const struct flb_tls_verifier_instance *tls_ins;
 
     if (!host || !port) {
         return NULL;
@@ -128,6 +130,12 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
         flb_upstream_node_destroy(node);
         return NULL;
     }
+
+    node->tls_verifier = flb_sds_create(tls_verifier);
+    if (!node->tls_verifier) {
+        flb_upstream_node_destroy(node);
+        return NULL;
+    }
 #endif
 
     /* hash table */
@@ -136,6 +144,7 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
 #ifdef FLB_HAVE_TLS
     /* TLS setup */
     if (tls == FLB_TRUE) {
+        tls_ins = find_tls_verifier_instance(config, tls_verifier);
         node->tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
                                    tls_verify,
                                    tls_debug,
@@ -145,7 +154,8 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
                                    tls_crt_file,
                                    tls_key_file,
                                    tls_key_passwd, 
-                                   tls_provider_query);
+                                   tls_provider_query,
+                                   tls_ins);
         if (!node->tls) {
             flb_error("[upstream_node] error initializing TLS context "
                       "on node '%s'", name);
@@ -224,6 +234,7 @@ void flb_upstream_node_destroy(struct flb_upstream_node *node)
     flb_sds_destroy(node->tls_key_file);
     flb_sds_destroy(node->tls_key_passwd);
     flb_sds_destroy(node->tls_provider_query);
+    flb_sds_destroy(node->tls_verifier);
     if (node->tls) {
         flb_tls_destroy(node->tls);
     }

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -104,6 +104,12 @@ struct flb_config_map tls_configmap[] = {
      "OpenSSL Provider Query to use for TLS operations"
      },
 
+    {
+     FLB_CONFIG_MAP_STR, "tls.tls_verifier", NULL,
+     0, FLB_FALSE, 0,
+     "Plugin alias to use for custom TLS verification."
+    },
+
     /* EOF */
     {0}
 };
@@ -195,7 +201,8 @@ struct flb_tls *flb_tls_create(int mode,
                                const char *crt_file,
                                const char *key_file,
                                const char *key_passwd,
-                               const char *additional_data)
+                               const char *additional_data,
+                               const struct flb_tls_verifier_instance *tls_ins)
 {
     void *backend;
     struct flb_tls *tls;
@@ -207,7 +214,7 @@ struct flb_tls *flb_tls_create(int mode,
     backend = tls_context_create(verify, debug, mode,
                                  vhost, ca_path, ca_file,
                                  crt_file, key_file, key_passwd,
-                                 additional_data);
+                                 additional_data, tls_ins);
     if (!backend) {
         flb_error("[tls] could not create TLS backend");
         return NULL;

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -908,10 +908,10 @@ static void *tls_context_create(int verify,
             goto error;
         }
         ret = X509_STORE_set_ex_data(store,
-                                     0,
+                                     FLB_X509_STORE_EX_INDEX,
                                      (struct flb_tls_verifier_instance *)tls_ins);
         if (ret != 1) {
-            flb_error("[tls] Failed to set log in X509_STORE ex data");
+            flb_error("[tls] Failed to set tls_verifier_instance in X509_STORE ex data");
             goto error;
         }
     }

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -826,13 +826,19 @@ static void *tls_context_create(int verify,
                                 const char *crt_file,
                                 const char *key_file,
                                 const char *key_passwd,
-                                const char *provider_query)
+                                const char *provider_query,
+                                const struct flb_tls_verifier_instance *tls_ins)
 {
     int ret;
     SSL_CTX *ssl_ctx;
     struct tls_context *ctx;
     char err_buf[256];
     char *key_log_filename;
+    X509_STORE* store = NULL;
+    SSL_verify_cb verify_cb = NULL;
+    if (tls_ins) {
+        verify_cb = tls_ins->plugin->cb_verify;
+    }
 
     /*
      * Init library ? based in the documentation on OpenSSL >= 1.1.0 is not longer
@@ -895,12 +901,27 @@ static void *tls_context_create(int verify,
 #endif
     pthread_mutex_init(&ctx->mutex, NULL);
 
+    if (verify_cb) {
+        store = SSL_CTX_get_cert_store(ssl_ctx);
+        if (!store) {
+            flb_error("[tls] failed to retrieve openssl certificate store.");
+            goto error;
+        }
+        ret = X509_STORE_set_ex_data(store,
+                                     0,
+                                     (struct flb_tls_verifier_instance *)tls_ins);
+        if (ret != 1) {
+            flb_error("[tls] Failed to set log in X509_STORE ex data");
+            goto error;
+        }
+    }
+
     /* Verify peer: by default OpenSSL always verify peer */
     if (verify == FLB_FALSE) {
         SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_NONE, NULL);
     }
     else {
-        SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);
+        SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, verify_cb);
     }
 
     /* ca_path | ca_file */

--- a/tests/runtime/in_tcp.c
+++ b/tests/runtime/in_tcp.c
@@ -374,6 +374,7 @@ void flb_test_tcp_with_tls()
                          NULL,
                          NULL,
                          NULL,
+                         NULL,
                          NULL);
 
     TEST_CHECK(tls != NULL);

--- a/tests/runtime/out_tcp.c
+++ b/tests/runtime/out_tcp.c
@@ -331,6 +331,7 @@ void flb_test_tcp_with_tls()
                          TLS_CERTIFICATE_FILENAME,
                          TLS_PRIVATE_KEY_FILENAME,
                          NULL,
+                         NULL,
                          NULL);
 
     TEST_CHECK(tls != NULL);


### PR DESCRIPTION
Added the ability to allow for more custom TLS verification by creating a new tls_verifier plugin, with the ability to define the OpenSSL callback for the `SSL_CTX_set_verify` function. If a plugin is configured to use TLS, and has an assigned tls_verifier, during the creation of the TLS connection the assigned tls_verifier callback function will be set to the OpenSSL's SSL_CTX.

during the TLS connection handshake, OpenSSL will call on the callback function, allowing Fluent Bit to have more custom control for verification with access to this callback. The tls_verifier callback will only be called if `tls.verify` is `on`

this allows for external tls_verifier plugins to be loaded in the `plugins` section of a yaml conf following the existing format for external plugins, for a tls_verifier it it expected to be in the file name format `flb-tls_verifier_<plugin-name>.so`

----

**Testing**
- [X] Example configuration file for the change
```
service:
  log_level: trace
  http_server: on
  http_listen: 0.0.0.0
  http_port: 2020
  hot_reload: on
plugins:
  - path/to/external/plugin/file/flb-tls_verifier_serverhash.so

tls_verifiers:
  - name: serverhash
    alias: ggl-serverhash
    hash: <SHA hash to verifiy against>

pipeline:
  inputs:
    - name: dummy
      dummy: '{"message": "Hello from Fluent Bit!"}'

  outputs:
    - name: opentelemetry
      host: localhost
      port: 8909
      match: '*'
      tls: on
      tls.verify: on
      tls.verifier: ggl-serverhash
      tls.crt_file: path/to/cert/file/MyCertificate.crt
      tls.key_file: path/to/key/file/MyKey.key
```
- [X] Debug log output from testing the change
```
#
# ./fluent-bit -c ./fluent-bit.yaml
Fluent Bit v4.0.2
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/09/08 13:18:49] [debug] [tls] init
[2025/09/08 13:18:49] [debug] [tls] resetting providers
[2025/09/08 13:18:49] [debug] [tls] loading provider 'c7000'
[2025/09/08 13:18:50] [ info] [fluent bit] version=4.0.2, commit=499207549e, pid=859


[2025/09/08 13:18:50] [ info] [tls_verifier:serverhash:ggl-serverhash] enter: cb_serverhash_init


[2025/09/08 13:18:50] [ info] [storage] created root path /data/bert/fluent-bit/storage/
[2025/09/08 13:18:50] [ info] [storage] ver=1.5.3, type=memory+filesystem, sync=full, checksum=off, max_chunks_up=128
[2025/09/08 13:18:50] [ info] [storage] backlog input plugin: storage_backlog.1
[2025/09/08 13:18:50] [ info] [simd    ] disabled
[2025/09/08 13:18:50] [ info] [cmetrics] version=1.0.2
[2025/09/08 13:18:50] [ info] [ctraces ] version=0.6.6
[2025/09/08 13:18:50] [ info] [input:tail:tail.0] initializing
[2025/09/08 13:18:50] [ info] [input:tail:tail.0] storage_strategy='filesystem' (memory + filesystem)
[2025/09/08 13:18:50] [ info] [input:tail:tail.0] db: delete unmonitored stale inodes from the database: count=0
[2025/09/08 13:18:50] [ info] [input:storage_backlog:storage_backlog.1] initializing
[2025/09/08 13:18:50] [ info] [input:storage_backlog:storage_backlog.1] storage_strategy='memory' (memory only)
[2025/09/08 13:18:50] [ info] [input:storage_backlog:storage_backlog.1] queue memory limit: 95.4M
[2025/09/08 13:18:50] [ info] [sp] stream processor started
[2025/09/08 13:18:50] [ info] [input:tail:tail.0] inotify_fs_add(): inode=3 watch_fd=1 name=/var/log/messages-sys


[2025/09/08 13:18:50] [ info] enter: cb_serverhash_verify
[2025/09/08 13:18:50] [debug] [tls_verifier:serverhash:ggl-serverhash] cb_server_verify: depth=0, preverify_ok=0, error=18, message=self-signed certificate
[2025/09/08 13:18:50] [trace] [tls_verifier:serverhash:ggl-serverhash] cb_server_verify: leaf cert hash matches configured server hash


[2025/09/08 13:18:51] [ info] [output:opentelemetry:opentelemetry.0] 10.60.2.17:8909, HTTP status=200
[2025/09/08 13:18:51] [ info] [output:opentelemetry:opentelemetry.0] 10.60.2.17:8909, HTTP status=200
[2025/09/08 13:19:11] [engine] caught signal (SIGHUP)
[2025/09/08 13:19:11] [ info] reloading instance pid=859 tid=0xf7195506e020
[2025/09/08 13:19:11] [ info] [reload] stop everything of the old context
[2025/09/08 13:19:11] [ warn] [engine] service will shutdown when all remaining tasks are flushed
[2025/09/08 13:19:11] [ info] [input] pausing tail.0
[2025/09/08 13:19:11] [ info] [input] pausing storage_backlog.1
[2025/09/08 13:19:12] [ info] [engine] service has stopped (0 pending tasks)
[2025/09/08 13:19:12] [ info] [input] pausing tail.0
[2025/09/08 13:19:12] [ info] [input] pausing storage_backlog.1
[2025/09/08 13:19:12] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=3 watch_fd=1
[2025/09/08 13:19:12] [debug] [tls] resetting providers
[2025/09/08 13:19:12] [ info] [reload] start everything
[2025/09/08 13:19:12] [debug] [tls] resetting providers
[2025/09/08 13:19:12] [debug] [tls] loading provider 'c7000'
[2025/09/08 13:19:12] [ info] [fluent bit] version=4.0.2, commit=499207549e, pid=859

[2025/09/08 13:19:12] [ info] [tls_verifier:serverhash:ggl-serverhash] enter: cb_serverhash_init

[2025/09/08 13:19:12] [ info] [storage] ver=1.5.3, type=memory+filesystem, sync=full, checksum=off, max_chunks_up=128
[2025/09/08 13:19:12] [ info] [storage] backlog input plugin: storage_backlog.1
[2025/09/08 13:19:12] [ info] [simd    ] disabled
[2025/09/08 13:19:12] [ info] [cmetrics] version=1.0.2
[2025/09/08 13:19:12] [ info] [ctraces ] version=0.6.6
[2025/09/08 13:19:12] [ info] [input:tail:tail.0] initializing
[2025/09/08 13:19:12] [ info] [input:tail:tail.0] storage_strategy='filesystem' (memory + filesystem)
[2025/09/08 13:19:12] [ info] [input:tail:tail.0] db: delete unmonitored stale inodes from the database: count=0
[2025/09/08 13:19:12] [ info] [input:storage_backlog:storage_backlog.1] initializing
[2025/09/08 13:19:12] [ info] [input:storage_backlog:storage_backlog.1] storage_strategy='memory' (memory only)
[2025/09/08 13:19:12] [ info] [input:storage_backlog:storage_backlog.1] queue memory limit: 95.4M
[2025/09/08 13:19:12] [ info] [sp] stream processor started
[2025/09/08 13:19:12] [ info] [input:tail:tail.0] inotify_fs_add(): inode=3 watch_fd=1 name=/var/log/messages-sys


[2025/09/08 13:20:49] [ info] enter: cb_serverhash_verify
[2025/09/08 13:20:49] [debug] [tls_verifier:serverhash:ggl-serverhash] cb_server_verify: depth=0, preverify_ok=0, error=18, message=self-signed certificate
[2025/09/08 13:20:49] [trace] [tls_verifier:serverhash:ggl-serverhash] cb_server_verify: leaf cert hash matches configured server hash


[2025/09/08 13:20:49] [ info] [output:opentelemetry:opentelemetry.0] 10.60.2.17:8909, HTTP status=200
```

This was tested on an embedded device, running an i.mx8 Processor with an EdgeLock chip for Secure World access.

- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
